### PR TITLE
feat: add structured AI responses and semantic search

### DIFF
--- a/ai-service/app.py
+++ b/ai-service/app.py
@@ -34,8 +34,10 @@ def create_app():
             response = process_financial_query(question, user_context=data.get("context"))
             
             return jsonify({
-                "answer": response["answer"],
-                "sources": response["sources"],
+                "title": response.get("title", ""),
+                "summary": response.get("summary", response.get("answer", "")),
+                "actionable_steps": response.get("actionable_steps", []),
+                "sources": response.get("sources", []),
                 "service": "ai-chatbot",
                 "provider": response.get("provider", "ai-agent"),
                 "agent_used": response.get("agent_used", False)

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -37,8 +37,10 @@ def ask():
             if response.status_code == 200:
                 ai_response = response.json()
                 return jsonify({
-                    "answer": ai_response["answer"],
-                    "sources": ai_response["sources"],
+                    "title": ai_response.get("title", ""),
+                    "summary": ai_response.get("summary", ai_response.get("answer", "")),
+                    "actionable_steps": ai_response.get("actionable_steps", []),
+                    "sources": ai_response.get("sources", []),
                     "provider": "ai-microservice"
                 })
             else:
@@ -56,14 +58,19 @@ def ask():
         conversation_history = data.get("conversation_history", [])
         
         # Process with the advanced AI agent
-        response = process_financial_query(question, user_context=user_context, conversation_history=conversation_history)
-        
+        response = process_financial_query(
+            question,
+            user_context=user_context,
+            conversation_history=conversation_history,
+        )
+
         return jsonify({
-            "answer": response["answer"],
-            "sources": response["sources"],
+            "title": response.get("title", ""),
+            "summary": response.get("summary", response.get("answer", "")),
+            "actionable_steps": response.get("actionable_steps", []),
+            "sources": response.get("sources", []),
             "provider": response.get("provider", "ai-agent"),
             "agent_used": response.get("agent_used", False),
-            "action_items": response.get("action_items", []),
             "priority_level": response.get("priority_level", "medium"),
             "follow_up_questions": response.get("follow_up_questions", []),
             "intent_classification": response.get("intent_classification", {})
@@ -73,7 +80,9 @@ def ask():
         # Final fallback to a generic error response
         print(f"Error in chat endpoint: {e}")
         return jsonify({
-            "answer": "I'm sorry, I'm having trouble processing your request right now. Please try again later or contact Houston/Harris County services directly for assistance.",
+            "title": "Service Unavailable",
+            "summary": "I'm sorry, I'm having trouble processing your request right now. Please try again later or contact Houston/Harris County services directly for assistance.",
+            "actionable_steps": [],
             "sources": [],
             "provider": "fallback"
         }), 500

--- a/utils/ai_agent.py
+++ b/utils/ai_agent.py
@@ -386,18 +386,24 @@ class HoustonFinancialAgent:
     def format_response(self, raw_response: Dict, query: str, context: Dict) -> Dict:
         """Format response with standardized structure"""
         intent_analysis = self.classify_intent(query)
-        
+        structured = raw_response.get("structured", {})
+        summary_text = structured.get("summary", raw_response.get("answer", ""))
+        steps = structured.get("actionable_steps") or self._extract_action_items(summary_text)
+
         formatted_response = {
-            "answer": raw_response.get("answer", ""),
-            "sources": raw_response.get("sources", []),
+            "answer": summary_text,
+            "title": structured.get("title", ""),
+            "summary": summary_text,
+            "actionable_steps": steps,
+            "action_items": steps,
+            "sources": raw_response.get("sources", structured.get("sources", [])),
             "provider": raw_response.get("provider", "unknown"),
             "agent_used": raw_response.get("agent_used", False),
-            "action_items": self._extract_action_items(raw_response.get("answer", "")),
             "priority_level": intent_analysis["primary_intent"]["priority"],
             "follow_up_questions": self._generate_clarifying_questions(query, context),
             "intent_classification": intent_analysis
         }
-        
+
         return formatted_response
     
     def _extract_action_items(self, answer: str) -> List[str]:
@@ -463,20 +469,21 @@ class HoustonFinancialAgent:
     
     def validate_response(self, response: Dict) -> Dict:
         """Ensure response quality before returning"""
-        answer = response.get("answer", "")
-        
-        # Enhance short responses
-        if len(answer) < 50:
-            response["answer"] = self._enhance_short_response(answer, response.get("sources", []))
-        
-        # Ensure sources are provided
+        summary = response.get("summary", "")
+
+        if len(summary) < 50:
+            enhanced = self._enhance_short_response(summary, response.get("sources", []))
+            response["summary"] = enhanced
+            response["answer"] = enhanced
+
         if not response.get("sources"):
             response["sources"] = get_default_houston_sources()[:3]
-        
-        # Add next steps if missing actionable content
-        if not self._contains_actionable_steps(answer):
-            response["answer"] += "\n\n" + self._add_next_steps(response.get("intent_classification", {}))
-        
+
+        if not self._contains_actionable_steps(summary) and not response.get("actionable_steps"):
+            addl = self._add_next_steps(response.get("intent_classification", {}))
+            response["summary"] += "\n\n" + addl
+            response["answer"] = response["summary"]
+
         return response
     
     def _enhance_short_response(self, answer: str, sources: List[Dict]) -> str:


### PR DESCRIPTION
## Summary
- switch Gemini prompt to return structured JSON with title, summary, and action steps
- add semantic search using Gemini embeddings for program retrieval
- expose structured fields (title, summary, actionable_steps) in AI service and chat routes

## Testing
- `python -m py_compile ai-service/app.py routes/chat.py utils/ai_agent.py utils/gemini_ai.py`


------
https://chatgpt.com/codex/tasks/task_e_68be196055a083268a777e8c68629c33