### PR TITLE
feat: add structured AI responses and semantic search

### DIFF
--- a/ai-service/app.py
+++ b/ai-service/app.py
@@ -34,8 +34,10 @@ def create_app():
             response = process_financial_query(question, user_context=data.get("context"))
             
             return jsonify({
-                "answer": response["answer"],
-                "sources": response["sources"],
+                "title": response.get("title", ""),
+                "summary": response.get("summary", response.get("answer", "")),
+                "actionable_steps": response.get("actionable_steps", []),
+                "sources": response.get("sources", []),
                 "service": "ai-chatbot",
                 "provider": response.get("provider", "ai-agent"),
                 "agent_used": response.get("agent_used", False)

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -37,8 +37,10 @@ def ask():
             if response.status_code == 200:
                 ai_response = response.json()
                 return jsonify({
-                    "answer": ai_response["answer"],
-                    "sources": ai_response["sources"],
+                    "title": ai_response.get("title", ""),
+                    "summary": ai_response.get("summary", ai_response.get("answer", "")),
+                    "actionable_steps": ai_response.get("actionable_steps", []),
+                    "sources": ai_response.get("sources", []),
                     "provider": "ai-microservice"
                 })
             else:
@@ -56,14 +58,19 @@ def ask():
         conversation_history = data.get("conversation_history", [])
         
         # Process with the advanced AI agent
-        response = process_financial_query(question, user_context=user_context, conversation_history=conversation_history)
-        
+        response = process_financial_query(
+            question,
+            user_context=user_context,
+            conversation_history=conversation_history,
+        )
+
         return jsonify({
-            "answer": response["answer"],
-            "sources": response["sources"],
+            "title": response.get("title", ""),
+            "summary": response.get("summary", response.get("answer", "")),
+            "actionable_steps": response.get("actionable_steps", []),
+            "sources": response.get("sources", []),
             "provider": response.get("provider", "ai-agent"),
             "agent_used": response.get("agent_used", False),
-            "action_items": response.get("action_items", []),
             "priority_level": response.get("priority_level", "medium"),
             "follow_up_questions": response.get("follow_up_questions", []),
             "intent_classification": response.get("intent_classification", {})
@@ -73,7 +80,9 @@ def ask():
         # Final fallback to a generic error response
         print(f"Error in chat endpoint: {e}")
         return jsonify({
-            "answer": "I'm sorry, I'm having trouble processing your request right now. Please try again later or contact Houston/Harris County services directly for assistance.",
+            "title": "Service Unavailable",
+            "summary": "I'm sorry, I'm having trouble processing your request right now. Please try again later or contact Houston/Harris County services directly for assistance.",
+            "actionable_steps": [],
             "sources": [],
             "provider": "fallback"
         }), 500

--- a/utils/ai_agent.py
+++ b/utils/ai_agent.py
@@ -386,18 +386,24 @@ class HoustonFinancialAgent:
     def format_response(self, raw_response: Dict, query: str, context: Dict) -> Dict:
         """Format response with standardized structure"""
         intent_analysis = self.classify_intent(query)
-        
+        structured = raw_response.get("structured", {})
+        summary_text = structured.get("summary", raw_response.get("answer", ""))
+        steps = structured.get("actionable_steps") or self._extract_action_items(summary_text)
+
         formatted_response = {
-            "answer": raw_response.get("answer", ""),
-            "sources": raw_response.get("sources", []),
+            "answer": summary_text,
+            "title": structured.get("title", ""),
+            "summary": summary_text,
+            "actionable_steps": steps,
+            "action_items": steps,
+            "sources": raw_response.get("sources", structured.get("sources", [])),
             "provider": raw_response.get("provider", "unknown"),
             "agent_used": raw_response.get("agent_used", False),
-            "action_items": self._extract_action_items(raw_response.get("answer", "")),
             "priority_level": intent_analysis["primary_intent"]["priority"],
             "follow_up_questions": self._generate_clarifying_questions(query, context),
             "intent_classification": intent_analysis
         }
-        
+
         return formatted_response
     
     def _extract_action_items(self, answer: str) -> List[str]:
@@ -463,20 +469,21 @@ class HoustonFinancialAgent:
     
     def validate_response(self, response: Dict) -> Dict:
         """Ensure response quality before returning"""
-        answer = response.get("answer", "")
-        
-        # Enhance short responses
-        if len(answer) < 50:
-            response["answer"] = self._enhance_short_response(answer, response.get("sources", []))
-        
-        # Ensure sources are provided
+        summary = response.get("summary", "")
+
+        if len(summary) < 50:
+            enhanced = self._enhance_short_response(summary, response.get("sources", []))
+            response["summary"] = enhanced
+            response["answer"] = enhanced
+
         if not response.get("sources"):
             response["sources"] = get_default_houston_sources()[:3]
-        
-        # Add next steps if missing actionable content
-        if not self._contains_actionable_steps(answer):
-            response["answer"] += "\n\n" + self._add_next_steps(response.get("intent_classification", {}))
-        
+
+        if not self._contains_actionable_steps(summary) and not response.get("actionable_steps"):
+            addl = self._add_next_steps(response.get("intent_classification", {}))
+            response["summary"] += "\n\n" + addl
+            response["answer"] = response["summary"]
+
         return response
     
     def _enhance_short_response(self, answer: str, sources: List[Dict]) -> str:
@@ -573,19 +580,17 @@ I apologize for the inconvenience and recommend trying again later.""",
             "action_items": ["Contact these organizations directly", "Try your specific question again later"],
             "priority_level": "medium"
         }
+
+    def _clarify_intent(self, question: str) -> str:
         """Ask clarifying questions to better understand user needs"""
-        clarifying_questions = """
-        To help you better, could you please clarify:
-        
-        1. What specific type of financial assistance do you need? (rent, utilities, food, etc.)
-        2. Are you a Harris County resident?
-        3. What's your current household size?
-        4. Do you have any specific urgent deadlines or situations?
-        5. Have you applied for assistance programs before?
-        
-        The more details you can provide, the better I can help you find the right resources.
-        """
-        return clarifying_questions.strip()
+        questions = self._generate_clarifying_questions(question)
+        if not questions:
+            return "Could you provide more details about your financial assistance needs?"
+
+        formatted = "To help you better, could you please clarify:\n\n"
+        for idx, q in enumerate(questions, 1):
+            formatted += f"{idx}. {q}\n"
+        return formatted.strip()
     
     def _get_agent_prompt(self) -> str:
         """Get the system prompt for the agent"""

--- a/utils/gemini_ai.py
+++ b/utils/gemini_ai.py
@@ -1,7 +1,10 @@
 # utils/gemini_ai.py
 import os
-import google.generativeai as genai
+import json
 from typing import List, Dict
+
+import google.generativeai as genai
+import numpy as np
 
 def configure_gemini():
     """Configure Gemini AI with API key"""
@@ -35,31 +38,33 @@ def test_gemini_connection():
         return False, f"Gemini connection failed: {str(e)}"
 
 def generate_financial_assistance_response(question: str, houston_data: List[Dict] = None, user_context: Dict = None) -> Dict:
-    """
-    Generate AI response for financial assistance questions using Gemini
-    
-    Args:
-        question: User's question about financial assistance
-        houston_data: Optional list of Houston financial assistance programs
-        user_context: Optional user context including location, household size, etc.
-    
-    Returns:
-        Dict with 'answer' and 'sources' keys
+    """Generate AI response for financial assistance questions using Gemini.
+
+    Returns a dictionary containing both a plain text summary (``answer``) for
+    backward compatibility and a ``structured`` field with rich data for the UI
+    (title, summary and actionable steps).
     """
     try:
         if not configure_gemini():
             # Fallback to mock response if Gemini not available
             return generate_mock_response(question, user_context)
-        
+
+        # Handle non-financial queries without calling the API
+        from .ai_agent import HoustonFinancialAgent
+        agent = HoustonFinancialAgent()
+        intent = agent.classify_intent(question)["primary_intent"]["intent"]
+        if intent == "non_financial":
+            return generate_mock_response(question, user_context)
+
         # Build context with Houston financial assistance data
         context = build_houston_context(houston_data)
         
         # Build enhanced user context
         user_context_str = build_user_context_string(user_context or {})
         
-        # Create the enhanced prompt
+        # Create the enhanced prompt expecting JSON output
         prompt = f"""
-You are a helpful financial assistant specializing in Houston/Harris County financial assistance programs. 
+You are a helpful financial assistant specializing in Houston/Harris County financial assistance programs.
 
 Context about available programs:
 {context}
@@ -69,25 +74,45 @@ User Context:
 
 User Question: {question}
 
-Please provide a helpful, accurate response about financial assistance programs in Houston/Harris County. 
-If you recommend specific programs, make sure they are from the Houston/Harris County area.
-Keep your response concise but informative.
-
-Consider the user's context when making recommendations and be specific about next steps.
-Format your response focusing on practical help and actionable next steps.
+Respond ONLY in valid JSON with the following structure:
+{{
+  "title": "short response title",
+  "summary": "3-5 sentence summary with actionable tone",
+  "actionable_steps": ["short imperative step", "additional step"],
+  "sources": []
+}}
+Do not add any additional text outside the JSON.
 """
 
         model = genai.GenerativeModel('gemini-pro')
         response = model.generate_content(prompt)
-        
+
         if response and response.text:
-            # Parse the AI response and combine with local data sources
-            ai_answer = response.text.strip()
-            sources = extract_relevant_sources(question, houston_data or get_default_houston_sources())
-            
+            raw_text = response.text.strip()
+            try:
+                parsed = json.loads(raw_text)
+            except json.JSONDecodeError:
+                parsed = {
+                    "title": "Financial Assistance Information",
+                    "summary": raw_text,
+                    "actionable_steps": [],
+                    "sources": []
+                }
+
+            sources = extract_relevant_sources(
+                question, houston_data or get_default_houston_sources()
+            )
+            structured = {
+                "title": parsed.get("title", ""),
+                "summary": parsed.get("summary", raw_text),
+                "actionable_steps": parsed.get("actionable_steps", []),
+                "sources": sources,
+            }
+
             return {
-                "answer": ai_answer,
-                "sources": sources
+                "answer": structured["summary"],
+                "structured": structured,
+                "sources": sources,
             }
         else:
             return generate_mock_response(question, user_context)
@@ -118,49 +143,73 @@ def build_user_context_string(user_context: Dict) -> str:
     
     if user_context.get("conversation_summary"):
         context_parts.append(f"Previous conversation: {user_context['conversation_summary']}")
-    
+
     return "; ".join(context_parts) if context_parts else "No specific user context provided"
+
+
+def build_houston_context(houston_data: List[Dict]) -> str:
     """Build context string from Houston assistance program data"""
     if not houston_data:
         houston_data = get_default_houston_sources()
-    
+
     context_parts = []
     for program in houston_data:
         context_part = f"- {program.get('name', 'Unknown Program')}: {program.get('why', 'Financial assistance program')}"
         if program.get('eligibility'):
             context_part += f" (Eligibility: {program['eligibility']})"
         context_parts.append(context_part)
-    
+
     return "\n".join(context_parts)
 
 def extract_relevant_sources(question: str, all_sources: List[Dict]) -> List[Dict]:
-    """Extract sources relevant to the user's question"""
-    question_lower = question.lower()
-    relevant_sources = []
-    
-    # Simple keyword matching for now - in production, this could use embeddings
-    for source in all_sources:
-        source_text = f"{source.get('name', '')} {source.get('why', '')}".lower()
-        
-        # Check for relevant keywords
-        if any(keyword in question_lower for keyword in ['rent', 'housing']) and \
-           any(keyword in source_text for keyword in ['rent', 'housing', 'shelter']):
-            relevant_sources.append(source)
-        elif any(keyword in question_lower for keyword in ['utility', 'electric', 'water', 'gas']) and \
-             any(keyword in source_text for keyword in ['utility', 'electric', 'water', 'gas', 'bill']):
-            relevant_sources.append(source)
-        elif any(keyword in question_lower for keyword in ['food', 'snap', 'hungry']) and \
-             any(keyword in source_text for keyword in ['food', 'snap', 'meal', 'nutrition']):
-            relevant_sources.append(source)
-        elif any(keyword in question_lower for keyword in ['home', 'buy', 'purchase', 'mortgage']) and \
-             any(keyword in source_text for keyword in ['home', 'buy', 'mortgage', 'purchase']):
-            relevant_sources.append(source)
-    
-    # If no specific matches, return a few general ones
-    if not relevant_sources:
-        relevant_sources = all_sources[:3]
-    
-    return relevant_sources[:5]  # Limit to 5 sources
+    """Extract sources relevant to the user's question using semantic search."""
+    try:
+        query_embedding = genai.embed_content(
+            model="models/embedding-001", content=question
+        )["embedding"]
+
+        source_embeddings = []
+        for src in all_sources:
+            text = f"{src.get('name', '')} {src.get('why', '')}"
+            embedding = genai.embed_content(
+                model="models/embedding-001", content=text
+            )["embedding"]
+            source_embeddings.append(embedding)
+
+        similarities = []
+        q = np.array(query_embedding)
+        q_norm = np.linalg.norm(q)
+        for emb, src in zip(source_embeddings, all_sources):
+            e = np.array(emb)
+            sim = float(np.dot(q, e) / (q_norm * np.linalg.norm(e)))
+            similarities.append((sim, src))
+
+        similarities.sort(key=lambda x: x[0], reverse=True)
+        ranked = [s for _, s in similarities]
+        return ranked[:5]
+    except Exception:
+        # Fallback to simple keyword matching
+        question_lower = question.lower()
+        relevant_sources = []
+
+        for source in all_sources:
+            source_text = f"{source.get('name', '')} {source.get('why', '')}".lower()
+            if any(k in question_lower for k in ['rent', 'housing']) and \
+               any(k in source_text for k in ['rent', 'housing', 'shelter']):
+                relevant_sources.append(source)
+            elif any(k in question_lower for k in ['utility', 'electric', 'water', 'gas']) and \
+                 any(k in source_text for k in ['utility', 'electric', 'water', 'gas', 'bill']):
+                relevant_sources.append(source)
+            elif any(k in question_lower for k in ['food', 'snap', 'hungry']) and \
+                 any(k in source_text for k in ['food', 'snap', 'meal', 'nutrition']):
+                relevant_sources.append(source)
+            elif any(k in question_lower for k in ['home', 'buy', 'purchase', 'mortgage']) and \
+                 any(k in source_text for k in ['home', 'buy', 'mortgage', 'purchase']):
+                relevant_sources.append(source)
+
+        if not relevant_sources:
+            relevant_sources = all_sources[:3]
+        return relevant_sources[:5]
 
 def get_default_houston_sources() -> List[Dict]:
     """Get default Houston financial assistance sources"""
@@ -269,13 +318,20 @@ def generate_mock_response(question: str, user_context: Dict = None) -> Dict:
 **I can help you with:**
 - Rental and housing assistance
 - Utility bill payment help
-- Food assistance programs  
+- Food assistance programs
 - Emergency financial aid
 - Budgeting and financial planning
 
 *How can I assist you with your financial needs today?*"""
+        structured = {
+            "title": "Financial Assistance Focus",
+            "summary": answer,
+            "actionable_steps": [],
+            "sources": []
+        }
         return {
-            "answer": answer,
+            "answer": structured["summary"],
+            "structured": structured,
             "sources": []
         }
     
@@ -308,8 +364,15 @@ def generate_mock_response(question: str, user_context: Dict = None) -> Dict:
 3. Look into assistance programs if your budget shows shortfalls"""
         
         relevant_sources = [s for s in sources if any(keyword in s['name'].lower() for keyword in ['community', 'counseling', 'assistance'])][:3]
+        structured = {
+            "title": "Budgeting Help",
+            "summary": answer,
+            "actionable_steps": [],
+            "sources": relevant_sources
+        }
         return {
-            "answer": answer,
+            "answer": structured["summary"],
+            "structured": structured,
             "sources": relevant_sources
         }
     
@@ -376,9 +439,16 @@ The **Houston Food Bank** is the largest food distribution organization in the a
 **To get more specific help:**
 *Could you be more specific about what type of assistance you need?*"""
         relevant_sources = sources[:3]
-    
+
+    structured = {
+        "title": "Financial Assistance Information",
+        "summary": answer,
+        "actionable_steps": [],
+        "sources": relevant_sources
+    }
     return {
-        "answer": answer,
+        "answer": structured["summary"],
+        "structured": structured,
         "sources": relevant_sources
     }
 


### PR DESCRIPTION
## Summary
- switch Gemini prompt to return structured JSON with title, summary, and action steps
- add semantic search using Gemini embeddings for program retrieval
- expose structured fields (title, summary, actionable_steps) in AI service and chat routes
- restore Houston context builder and clarify-intent tool to fix initialization errors
- handle non-financial queries before Gemini calls

## Testing
- `python -m py_compile utils/ai_agent.py utils/gemini_ai.py`


------
https://chatgpt.com/codex/tasks/task_e_68be196055a083268a777e8c68629c33