### PR TITLE
feat: add structured AI responses and semantic search

### DIFF
--- a/ai-service/app.py
+++ b/ai-service/app.py
@@ -34,8 +34,10 @@ def create_app():
             response = process_financial_query(question, user_context=data.get("context"))
             
             return jsonify({
-                "answer": response["answer"],
-                "sources": response["sources"],
+                "title": response.get("title", ""),
+                "summary": response.get("summary", ""),
+                "actionable_steps": response.get("actionable_steps", []),
+                "sources": response.get("sources", []),
                 "service": "ai-chatbot",
                 "provider": response.get("provider", "ai-agent"),
                 "agent_used": response.get("agent_used", False)

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -37,8 +37,10 @@ def ask():
             if response.status_code == 200:
                 ai_response = response.json()
                 return jsonify({
-                    "answer": ai_response["answer"],
-                    "sources": ai_response["sources"],
+                    "title": ai_response.get("title", ""),
+                    "summary": ai_response.get("summary", ""),
+                    "actionable_steps": ai_response.get("actionable_steps", []),
+                    "sources": ai_response.get("sources", []),
                     "provider": "ai-microservice"
                 })
             else:
@@ -56,14 +58,19 @@ def ask():
         conversation_history = data.get("conversation_history", [])
         
         # Process with the advanced AI agent
-        response = process_financial_query(question, user_context=user_context, conversation_history=conversation_history)
-        
+        response = process_financial_query(
+            question,
+            user_context=user_context,
+            conversation_history=conversation_history,
+        )
+
         return jsonify({
-            "answer": response["answer"],
-            "sources": response["sources"],
+            "title": response.get("title", ""),
+            "summary": response.get("summary", ""),
+            "actionable_steps": response.get("actionable_steps", []),
+            "sources": response.get("sources", []),
             "provider": response.get("provider", "ai-agent"),
             "agent_used": response.get("agent_used", False),
-            "action_items": response.get("action_items", []),
             "priority_level": response.get("priority_level", "medium"),
             "follow_up_questions": response.get("follow_up_questions", []),
             "intent_classification": response.get("intent_classification", {})
@@ -73,7 +80,9 @@ def ask():
         # Final fallback to a generic error response
         print(f"Error in chat endpoint: {e}")
         return jsonify({
-            "answer": "I'm sorry, I'm having trouble processing your request right now. Please try again later or contact Houston/Harris County services directly for assistance.",
+            "title": "Service Unavailable",
+            "summary": "I'm sorry, I'm having trouble processing your request right now. Please try again later or contact Houston/Harris County services directly for assistance.",
+            "actionable_steps": [],
             "sources": [],
             "provider": "fallback"
         }), 500

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -10,5 +10,5 @@ export const api = axios.create({
 
 export async function ask(question: string) {
   const { data } = await api.post("/ask", { question });
-  return data as { answer: string; sources: any[] };
+  return data as { summary: string; sources: any[] };
 }

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -22,7 +22,7 @@ export default function ChatPage() {
     setLoading(true);
     try {
       const data = await ask(q);
-      setMessages((m) => [...m, { role: "bot", content: data.answer, sources: data.sources as Source[] }]);
+      setMessages((m) => [...m, { role: "bot", content: data.summary, sources: data.sources as Source[] }]);
     } catch (e: any) {
       toast.error(e?.message || "Request failed");
       setMessages((m) => [...m, { role: "bot", content: `Sorry, something went wrong: ${e?.message || "error"}` }]);

--- a/utils/gemini_ai.py
+++ b/utils/gemini_ai.py
@@ -1,7 +1,10 @@
 # utils/gemini_ai.py
 import os
-import google.generativeai as genai
+import json
 from typing import List, Dict
+
+import google.generativeai as genai
+import numpy as np
 
 def configure_gemini():
     """Configure Gemini AI with API key"""
@@ -35,31 +38,32 @@ def test_gemini_connection():
         return False, f"Gemini connection failed: {str(e)}"
 
 def generate_financial_assistance_response(question: str, houston_data: List[Dict] = None, user_context: Dict = None) -> Dict:
-    """
-    Generate AI response for financial assistance questions using Gemini
-    
-    Args:
-        question: User's question about financial assistance
-        houston_data: Optional list of Houston financial assistance programs
-        user_context: Optional user context including location, household size, etc.
-    
-    Returns:
-        Dict with 'answer' and 'sources' keys
+    """Generate AI response for financial assistance questions using Gemini.
+
+    Returns a dictionary containing a structured response with a title, summary,
+    actionable steps, and sources.
     """
     try:
         if not configure_gemini():
             # Fallback to mock response if Gemini not available
             return generate_mock_response(question, user_context)
-        
+
+        # Handle non-financial queries without calling the API
+        from .ai_agent import HoustonFinancialAgent
+        agent = HoustonFinancialAgent()
+        intent = agent.classify_intent(question)["primary_intent"]["intent"]
+        if intent == "non_financial":
+            return generate_mock_response(question, user_context)
+
         # Build context with Houston financial assistance data
         context = build_houston_context(houston_data)
-        
+
         # Build enhanced user context
         user_context_str = build_user_context_string(user_context or {})
-        
-        # Create the enhanced prompt
+
+        # Create the enhanced prompt expecting JSON output
         prompt = f"""
-You are a helpful financial assistant specializing in Houston/Harris County financial assistance programs. 
+You are a helpful financial assistant specializing in Houston/Harris County financial assistance programs.
 
 Context about available programs:
 {context}
@@ -69,29 +73,44 @@ User Context:
 
 User Question: {question}
 
-Please provide a helpful, accurate response about financial assistance programs in Houston/Harris County. 
-If you recommend specific programs, make sure they are from the Houston/Harris County area.
-Keep your response concise but informative.
-
-Consider the user's context when making recommendations and be specific about next steps.
-Format your response focusing on practical help and actionable next steps.
+Respond ONLY in valid JSON with the following structure:
+{{
+  "title": "short response title",
+  "summary": "3-5 sentence summary with actionable tone",
+  "actionable_steps": ["short imperative step", "additional step"],
+  "sources": []
+}}
+Do not add any additional text outside the JSON.
 """
 
-        model = genai.GenerativeModel('gemini-pro')
+        model = genai.GenerativeModel('gemini-1.5-pro-latest')
         response = model.generate_content(prompt)
-        
+
         if response and response.text:
-            # Parse the AI response and combine with local data sources
-            ai_answer = response.text.strip()
-            sources = extract_relevant_sources(question, houston_data or get_default_houston_sources())
-            
+            raw_text = response.text.strip()
+            try:
+                parsed = json.loads(raw_text)
+            except json.JSONDecodeError:
+                parsed = {
+                    "title": "Financial Assistance Information",
+                    "summary": raw_text,
+                    "actionable_steps": [],
+                    "sources": []
+                }
+
+            sources = extract_relevant_sources(
+                question, houston_data or get_default_houston_sources()
+            )
+
             return {
-                "answer": ai_answer,
-                "sources": sources
+                "title": parsed.get("title", ""),
+                "summary": parsed.get("summary", raw_text),
+                "actionable_steps": parsed.get("actionable_steps", []),
+                "sources": sources,
             }
         else:
             return generate_mock_response(question, user_context)
-            
+
     except Exception as e:
         print(f"Error generating Gemini response: {e}")
         # Fallback to mock response on error
@@ -118,49 +137,73 @@ def build_user_context_string(user_context: Dict) -> str:
     
     if user_context.get("conversation_summary"):
         context_parts.append(f"Previous conversation: {user_context['conversation_summary']}")
-    
+
     return "; ".join(context_parts) if context_parts else "No specific user context provided"
+
+
+def build_houston_context(houston_data: List[Dict]) -> str:
     """Build context string from Houston assistance program data"""
     if not houston_data:
         houston_data = get_default_houston_sources()
-    
+
     context_parts = []
     for program in houston_data:
         context_part = f"- {program.get('name', 'Unknown Program')}: {program.get('why', 'Financial assistance program')}"
         if program.get('eligibility'):
             context_part += f" (Eligibility: {program['eligibility']})"
         context_parts.append(context_part)
-    
+
     return "\n".join(context_parts)
 
 def extract_relevant_sources(question: str, all_sources: List[Dict]) -> List[Dict]:
-    """Extract sources relevant to the user's question"""
-    question_lower = question.lower()
-    relevant_sources = []
-    
-    # Simple keyword matching for now - in production, this could use embeddings
-    for source in all_sources:
-        source_text = f"{source.get('name', '')} {source.get('why', '')}".lower()
-        
-        # Check for relevant keywords
-        if any(keyword in question_lower for keyword in ['rent', 'housing']) and \
-           any(keyword in source_text for keyword in ['rent', 'housing', 'shelter']):
-            relevant_sources.append(source)
-        elif any(keyword in question_lower for keyword in ['utility', 'electric', 'water', 'gas']) and \
-             any(keyword in source_text for keyword in ['utility', 'electric', 'water', 'gas', 'bill']):
-            relevant_sources.append(source)
-        elif any(keyword in question_lower for keyword in ['food', 'snap', 'hungry']) and \
-             any(keyword in source_text for keyword in ['food', 'snap', 'meal', 'nutrition']):
-            relevant_sources.append(source)
-        elif any(keyword in question_lower for keyword in ['home', 'buy', 'purchase', 'mortgage']) and \
-             any(keyword in source_text for keyword in ['home', 'buy', 'mortgage', 'purchase']):
-            relevant_sources.append(source)
-    
-    # If no specific matches, return a few general ones
-    if not relevant_sources:
-        relevant_sources = all_sources[:3]
-    
-    return relevant_sources[:5]  # Limit to 5 sources
+    """Extract sources relevant to the user's question using semantic search."""
+    try:
+        query_embedding = genai.embed_content(
+            model="models/embedding-001", content=question
+        )["embedding"]
+
+        source_embeddings = []
+        for src in all_sources:
+            text = f"{src.get('name', '')} {src.get('why', '')}"
+            embedding = genai.embed_content(
+                model="models/embedding-001", content=text
+            )["embedding"]
+            source_embeddings.append(embedding)
+
+        similarities = []
+        q = np.array(query_embedding)
+        q_norm = np.linalg.norm(q)
+        for emb, src in zip(source_embeddings, all_sources):
+            e = np.array(emb)
+            sim = float(np.dot(q, e) / (q_norm * np.linalg.norm(e)))
+            similarities.append((sim, src))
+
+        similarities.sort(key=lambda x: x[0], reverse=True)
+        ranked = [s for _, s in similarities]
+        return ranked[:5]
+    except Exception:
+        # Fallback to simple keyword matching
+        question_lower = question.lower()
+        relevant_sources = []
+
+        for source in all_sources:
+            source_text = f"{source.get('name', '')} {source.get('why', '')}".lower()
+            if any(k in question_lower for k in ['rent', 'housing']) and \
+               any(k in source_text for k in ['rent', 'housing', 'shelter']):
+                relevant_sources.append(source)
+            elif any(k in question_lower for k in ['utility', 'electric', 'water', 'gas']) and \
+                 any(k in source_text for k in ['utility', 'electric', 'water', 'gas', 'bill']):
+                relevant_sources.append(source)
+            elif any(k in question_lower for k in ['food', 'snap', 'hungry']) and \
+                 any(k in source_text for k in ['food', 'snap', 'meal', 'nutrition']):
+                relevant_sources.append(source)
+            elif any(k in question_lower for k in ['home', 'buy', 'purchase', 'mortgage']) and \
+                 any(k in source_text for k in ['home', 'buy', 'mortgage', 'purchase']):
+                relevant_sources.append(source)
+
+        if not relevant_sources:
+            relevant_sources = all_sources[:3]
+        return relevant_sources[:5]
 
 def get_default_houston_sources() -> List[Dict]:
     """Get default Houston financial assistance sources"""
@@ -269,13 +312,20 @@ def generate_mock_response(question: str, user_context: Dict = None) -> Dict:
 **I can help you with:**
 - Rental and housing assistance
 - Utility bill payment help
-- Food assistance programs  
+- Food assistance programs
 - Emergency financial aid
 - Budgeting and financial planning
 
 *How can I assist you with your financial needs today?*"""
+        structured = {
+            "title": "Financial Assistance Focus",
+            "summary": answer,
+            "actionable_steps": [],
+            "sources": []
+        }
         return {
-            "answer": answer,
+            "answer": structured["summary"],
+            "structured": structured,
             "sources": []
         }
     
@@ -308,8 +358,15 @@ def generate_mock_response(question: str, user_context: Dict = None) -> Dict:
 3. Look into assistance programs if your budget shows shortfalls"""
         
         relevant_sources = [s for s in sources if any(keyword in s['name'].lower() for keyword in ['community', 'counseling', 'assistance'])][:3]
+        structured = {
+            "title": "Budgeting Help",
+            "summary": answer,
+            "actionable_steps": [],
+            "sources": relevant_sources
+        }
         return {
-            "answer": answer,
+            "answer": structured["summary"],
+            "structured": structured,
             "sources": relevant_sources
         }
     
@@ -376,9 +433,16 @@ The **Houston Food Bank** is the largest food distribution organization in the a
 **To get more specific help:**
 *Could you be more specific about what type of assistance you need?*"""
         relevant_sources = sources[:3]
-    
+
+    structured = {
+        "title": "Financial Assistance Information",
+        "summary": answer,
+        "actionable_steps": [],
+        "sources": relevant_sources
+    }
     return {
-        "answer": answer,
+        "answer": structured["summary"],
+        "structured": structured,
         "sources": relevant_sources
     }
 


### PR DESCRIPTION
## Summary
- switch Gemini prompt to return structured JSON with title, summary, and action steps
- add semantic search using Gemini embeddings for program retrieval
- expose structured fields in AI service and chat routes
- update frontend to consume `summary` field and avoid blank replies

## Testing
- `python -m py_compile ai-service/app.py routes/chat.py utils/ai_agent.py utils/gemini_ai.py`
- no additional tests run (per user request)


------
https://chatgpt.com/codex/tasks/task_e_68be196055a083268a777e8c68629c33