### PR TITLE
fix: convert system messages for gemini agent

### DIFF
--- a/utils/ai_agent.py
+++ b/utils/ai_agent.py
@@ -81,7 +81,8 @@ class HoustonFinancialAgent:
             llm = ChatGoogleGenerativeAI(
                 model="gemini-1.5-pro-latest",
                 google_api_key=api_key,
-                temperature=0.3
+                temperature=0.3,
+                convert_system_message_to_human=True
             )
             
             # Initialize memory


### PR DESCRIPTION
## Summary
- enable `convert_system_message_to_human` in ChatGoogleGenerativeAI initialization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be339bf3808326815b7e32fdcb7f12