### PR TITLE
Unify dark theme styling across chat and auth pages

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
 import { Link, NavLink, useNavigate } from "react-router-dom";
 import { useAuth } from "@/context/Auth";
 import { logout } from "@/api/auth";
-import { DollarSign, LogOut, Zap, TrendingUp } from "lucide-react";
+import { LogOut, Zap, TrendingUp } from "lucide-react";
 import toast from "react-hot-toast";
 
 export default function Navbar() {
@@ -20,29 +20,33 @@ export default function Navbar() {
   };
 
   return (
-    <nav className="border-b border-gray-200 bg-white sticky top-0 z-50">
+    <nav className="border-b border-dark-400 bg-dark-200/80 backdrop-blur-sm sticky top-0 z-50">
       <div className="container mx-auto px-4 py-4">
         <div className="flex items-center justify-between">
-          <Link to="/" className="flex items-center space-x-3 text-black hover:text-blue-600 transition-colors">
-            <div className="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center">
+          <Link to="/" className="flex items-center space-x-3 text-white hover:text-primary-500 transition-colors">
+            <div className="w-8 h-8 bg-primary-500 rounded-lg flex items-center justify-center">
               <Zap className="w-5 h-5 text-white" />
             </div>
             <div>
-              <h1 className="text-xl font-bold text-black">Houston Financial Navigator</h1>
-              <p className="text-xs text-black">Smart Financial Management</p>
+              <h1 className="text-xl font-bold text-white">Houston Financial Navigator</h1>
+              <p className="text-xs text-dark-900">Smart Financial Management</p>
             </div>
           </Link>
 
-          <div className="flex items-center space-x-6 text-sm text-black">
+          <div className="flex items-center space-x-6 text-sm text-dark-900">
             <NavLink
               to="/chat"
-              className={({isActive}) => `transition-colors ${isActive ? "text-blue-600 font-medium" : "text-black hover:text-blue-600"}`}
+              className={({ isActive }) =>
+                `transition-colors ${isActive ? "text-primary-500 font-medium" : "text-dark-900 hover:text-primary-500"}`
+              }
             >
               Chat
             </NavLink>
             <NavLink
               to="/learn"
-              className={({isActive}) => `transition-colors ${isActive ? "text-blue-600 font-medium" : "text-black hover:text-blue-600"}`}
+              className={({ isActive }) =>
+                `transition-colors ${isActive ? "text-primary-500 font-medium" : "text-dark-900 hover:text-primary-500"}`
+              }
             >
               Learn
             </NavLink>
@@ -50,13 +54,17 @@ export default function Navbar() {
               <>
                 <NavLink
                   to="/dashboard"
-                  className={({isActive}) => `transition-colors ${isActive ? "text-blue-600 font-medium" : "text-black hover:text-blue-600"}`}
+                  className={({ isActive }) =>
+                    `transition-colors ${isActive ? "text-primary-500 font-medium" : "text-dark-900 hover:text-primary-500"}`
+                  }
                 >
                   Dashboard
                 </NavLink>
                 <NavLink
                   to="/trustagent"
-                  className={({isActive}) => `transition-colors ${isActive ? "text-blue-600 font-medium" : "text-black hover:text-blue-600"}`}
+                  className={({ isActive }) =>
+                    `transition-colors ${isActive ? "text-primary-500 font-medium" : "text-dark-900 hover:text-primary-500"}`
+                  }
                 >
                   TrustAgent
                 </NavLink>
@@ -65,27 +73,29 @@ export default function Navbar() {
             {user?.role === "admin" && (
               <NavLink
                 to="/admin"
-                className={({isActive}) => `transition-colors ${isActive ? "text-blue-600 font-medium" : "text-black hover:text-blue-600"}`}
+                className={({ isActive }) =>
+                  `transition-colors ${isActive ? "text-primary-500 font-medium" : "text-dark-900 hover:text-primary-500"}`
+                }
               >
                 Admin
               </NavLink>
             )}
 
-            <div className="hidden md:flex items-center space-x-2 text-sm text-black">
+            <div className="hidden md:flex items-center space-x-2 text-sm text-dark-900">
               <TrendingUp className="w-4 h-4" />
               <span>Real-time Analysis</span>
             </div>
 
-            <div className="border-l border-gray-200 pl-6 flex items-center gap-4">
+            <div className="border-l border-dark-400 pl-6 flex items-center gap-4">
               {!loading && (
                 user ? (
                   <div className="flex items-center gap-3">
-                    <span className="text-black font-medium">
+                    <span className="text-white font-medium">
                       {user.first_name || user.email}
                     </span>
                     <button
                       onClick={handleLogout}
-                      className="flex items-center gap-1 text-black hover:text-blue-600 transition-colors"
+                      className="flex items-center gap-1 text-dark-900 hover:text-primary-500 transition-colors"
                     >
                       <LogOut className="h-4 w-4" />
                       <span>Sign Out</span>
@@ -95,13 +105,13 @@ export default function Navbar() {
                   <>
                     <Link
                       to="/login"
-                      className="text-black hover:text-blue-600 transition-colors"
+                      className="text-dark-900 hover:text-primary-500 transition-colors"
                     >
                       Sign In
                     </Link>
                     <Link
                       to="/register"
-                      className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1.5 rounded-lg transition-all duration-200 text-sm shadow-lg"
+                      className="bg-primary-500 hover:bg-primary-600 text-white px-3 py-1.5 rounded-lg transition-all duration-200 text-sm shadow-lg"
                     >
                       Sign Up
                     </Link>

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -344,7 +344,7 @@ export default function ChatPage() {
                 )}
               </div>
 
-              <div className="border-t bg-white p-6">
+              <div className="border-t border-dark-400 bg-dark-200 p-6">
                 <form
                   onSubmit={(event) => {
                     event.preventDefault();
@@ -357,14 +357,14 @@ export default function ChatPage() {
                       value={input}
                       onChange={(event) => setInput(event.target.value)}
                       placeholder="Ask about rent, utilities, SNAP, homebuyer aid…"
-                      className="w-full rounded-xl border-2 border-gray-200 bg-gray-50 px-4 py-3 text-gray-900 placeholder-gray-500 focus:border-blue-500 focus:bg-white focus:outline-none transition-all"
+                      className="w-full rounded-xl border-2 border-dark-400 bg-dark-300 px-4 py-3 text-dark-900 placeholder-dark-700 focus:border-primary-500 focus:bg-dark-400 focus:outline-none transition-all"
                       disabled={loading}
                     />
                   </div>
                   <button
                     type="submit"
                     disabled={loading || !input.trim()}
-                    className="rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 px-6 py-3 text-white font-medium disabled:opacity-50 disabled:cursor-not-allowed hover:from-blue-700 hover:to-indigo-700 transition-all duration-200 flex items-center space-x-2 shadow-lg"
+                    className="rounded-xl bg-gradient-to-r from-primary-500 to-primary-600 px-6 py-3 text-white font-medium disabled:opacity-50 disabled:cursor-not-allowed hover:from-primary-600 hover:to-primary-700 transition-all duration-200 flex items-center space-x-2 shadow-lg"
                   >
                     <Send className="h-4 w-4" />
                     <span>{loading ? "Thinking…" : "Ask"}</span>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -40,16 +40,16 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="flex items-center justify-center py-12 px-4 bg-white min-h-[calc(100vh-8rem)]">
-      <div className="max-w-2xl w-full bg-white border border-gray-200 rounded-2xl shadow-sm p-8">
+    <div className="flex items-center justify-center py-12 px-4 bg-dark-100 min-h-[calc(100vh-8rem)]">
+      <div className="max-w-2xl w-full bg-dark-200 border border-dark-400 rounded-2xl shadow-xl p-8">
         <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-black mb-2">Welcome Back</h1>
-          <p className="text-black">Sign in to your Houston Financial Navigator account</p>
+          <h1 className="text-3xl font-bold text-white mb-2">Welcome Back</h1>
+          <p className="text-dark-900">Sign in to your Houston Financial Navigator account</p>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-4 text-black">
+        <form onSubmit={handleSubmit} className="space-y-4 text-white">
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-black mb-1">
+            <label htmlFor="email" className="block text-sm font-medium text-dark-900 mb-1">
               Email
             </label>
             <input
@@ -58,13 +58,13 @@ export default function LoginPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all text-black"
+              className="w-full px-4 py-3 border border-dark-400 bg-dark-300 text-white placeholder-dark-700 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all"
               placeholder="your@email.com"
             />
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-black mb-1">
+            <label htmlFor="password" className="block text-sm font-medium text-dark-900 mb-1">
               Password
             </label>
             <input
@@ -73,7 +73,7 @@ export default function LoginPage() {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all text-black"
+              className="w-full px-4 py-3 border border-dark-400 bg-dark-300 text-white placeholder-dark-700 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all"
               placeholder="••••••••"
             />
           </div>
@@ -81,7 +81,7 @@ export default function LoginPage() {
           <button
             type="submit"
             disabled={loading}
-            className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 text-white py-3 px-4 rounded-lg font-semibold disabled:opacity-60 disabled:cursor-not-allowed hover:from-blue-700 hover:to-indigo-700 transition-all duration-200 shadow-lg"
+            className="w-full bg-gradient-to-r from-primary-500 to-primary-600 text-white py-3 px-4 rounded-lg font-semibold disabled:opacity-60 disabled:cursor-not-allowed hover:from-primary-600 hover:to-primary-700 transition-all duration-200 shadow-lg"
           >
             {loading ? (
               <div className="flex items-center justify-center space-x-2">
@@ -95,9 +95,9 @@ export default function LoginPage() {
         </form>
 
         <div className="mt-6 text-center">
-          <p className="text-black">
+          <p className="text-dark-900">
             Don't have an account?{" "}
-            <Link to="/register" className="text-blue-600 hover:text-blue-800 font-medium">
+            <Link to="/register" className="text-primary-500 hover:text-primary-400 font-medium">
               Sign up
             </Link>
           </p>

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -31,23 +31,23 @@ export default function Onboarding() {
   };
 
   return (
-    <div className="flex items-center justify-center py-12 px-4 bg-white min-h-[calc(100vh-8rem)]">
-      <div className="max-w-2xl w-full bg-white border border-gray-200 rounded-2xl shadow-sm p-8 space-y-6">
+    <div className="flex items-center justify-center py-12 px-4 bg-dark-100 min-h-[calc(100vh-8rem)]">
+      <div className="max-w-2xl w-full bg-dark-200 border border-dark-400 rounded-2xl shadow-xl p-8 space-y-6">
         <div className="text-center">
-          <h1 className="text-3xl font-bold text-black mb-2">
+          <h1 className="text-3xl font-bold text-white mb-2">
             Welcome to Houston Financial Navigator
           </h1>
-          <p className="text-black">
+          <p className="text-dark-900">
             Let's set up your personalized financial dashboard
           </p>
         </div>
 
         <div className="space-y-4">
-          <div className="bg-blue-50 rounded-lg p-4 border border-blue-200">
-            <h2 className="text-lg font-semibold text-blue-900 mb-2">
+          <div className="bg-dark-300/60 rounded-lg p-4 border border-dark-400">
+            <h2 className="text-lg font-semibold text-white mb-2">
               What we'll create for you:
             </h2>
-            <ul className="text-blue-800 space-y-1 text-sm">
+            <ul className="text-dark-900 space-y-1 text-sm">
               <li>• A sandbox customer profile</li>
               <li>• A checking account with sample transactions</li>
               <li>• Your personalized financial dashboard</li>
@@ -57,7 +57,7 @@ export default function Onboarding() {
           <button
             disabled={busy}
             onClick={handleSetup}
-            className="w-full rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 text-white px-6 py-4 font-semibold disabled:opacity-60 disabled:cursor-not-allowed hover:from-blue-700 hover:to-indigo-700 transition-all duration-200 shadow-lg"
+            className="w-full rounded-xl bg-gradient-to-r from-primary-500 to-primary-600 text-white px-6 py-4 font-semibold disabled:opacity-60 disabled:cursor-not-allowed hover:from-primary-600 hover:to-primary-700 transition-all duration-200 shadow-lg"
           >
             {busy ? (
               <div className="flex items-center justify-center space-x-2">
@@ -71,7 +71,7 @@ export default function Onboarding() {
         </div>
 
         <div className="text-center">
-          <p className="text-sm text-black">
+          <p className="text-sm text-dark-900">
             This will create a demo account with sample data for learning purposes
           </p>
         </div>

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -39,17 +39,17 @@ export default function RegisterPage() {
   };
 
   return (
-    <div className="flex items-center justify-center py-12 px-4 bg-white min-h-[calc(100vh-8rem)] text-black">
-      <div className="max-w-2xl w-full bg-white border border-gray-200 rounded-2xl shadow-sm p-8">
+    <div className="flex items-center justify-center py-12 px-4 bg-dark-100 min-h-[calc(100vh-8rem)] text-white">
+      <div className="max-w-2xl w-full bg-dark-200 border border-dark-400 rounded-2xl shadow-xl p-8">
         <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-black mb-2">Join Houston Financial Navigator</h1>
-          <p className="text-black">Create your account to start your financial journey</p>
+          <h1 className="text-3xl font-bold text-white mb-2">Join Houston Financial Navigator</h1>
+          <p className="text-dark-900">Create your account to start your financial journey</p>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-4 text-black">
+        <form onSubmit={handleSubmit} className="space-y-4 text-white">
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label htmlFor="first_name" className="block text-sm font-medium text-black mb-1">
+              <label htmlFor="first_name" className="block text-sm font-medium text-dark-900 mb-1">
                 First Name
               </label>
               <input
@@ -58,12 +58,12 @@ export default function RegisterPage() {
                 type="text"
                 value={formData.first_name}
                 onChange={handleChange}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all text-black"
+                className="w-full px-4 py-3 border border-dark-400 bg-dark-300 text-white placeholder-dark-700 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all"
                 placeholder="John"
               />
             </div>
             <div>
-              <label htmlFor="last_name" className="block text-sm font-medium text-black mb-1">
+              <label htmlFor="last_name" className="block text-sm font-medium text-dark-900 mb-1">
                 Last Name
               </label>
               <input
@@ -72,14 +72,14 @@ export default function RegisterPage() {
                 type="text"
                 value={formData.last_name}
                 onChange={handleChange}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all text-black"
+                className="w-full px-4 py-3 border border-dark-400 bg-dark-300 text-white placeholder-dark-700 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all"
                 placeholder="Doe"
               />
             </div>
           </div>
 
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-black mb-1">
+            <label htmlFor="email" className="block text-sm font-medium text-dark-900 mb-1">
               Email
             </label>
             <input
@@ -89,13 +89,13 @@ export default function RegisterPage() {
               value={formData.email}
               onChange={handleChange}
               required
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all text-black"
+              className="w-full px-4 py-3 border border-dark-400 bg-dark-300 text-white placeholder-dark-700 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all"
               placeholder="your@email.com"
             />
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-black mb-1">
+            <label htmlFor="password" className="block text-sm font-medium text-dark-900 mb-1">
               Password
             </label>
             <input
@@ -105,7 +105,7 @@ export default function RegisterPage() {
               value={formData.password}
               onChange={handleChange}
               required
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all text-black"
+              className="w-full px-4 py-3 border border-dark-400 bg-dark-300 text-white placeholder-dark-700 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all"
               placeholder="••••••••"
             />
           </div>
@@ -113,7 +113,7 @@ export default function RegisterPage() {
           <button
             type="submit"
             disabled={loading}
-            className="w-full bg-blue-600 text-white py-3 px-4 rounded-lg font-semibold disabled:opacity-60 disabled:cursor-not-allowed hover:bg-blue-700 transition-all duration-200 shadow-sm"
+            className="w-full bg-gradient-to-r from-primary-500 to-primary-600 text-white py-3 px-4 rounded-lg font-semibold disabled:opacity-60 disabled:cursor-not-allowed hover:from-primary-600 hover:to-primary-700 transition-all duration-200 shadow-lg"
           >
             {loading ? (
               <div className="flex items-center justify-center space-x-2">
@@ -127,9 +127,9 @@ export default function RegisterPage() {
         </form>
 
         <div className="mt-6 text-center">
-          <p className="text-black">
+          <p className="text-dark-900">
             Already have an account?{" "}
-            <Link to="/login" className="text-blue-600 hover:text-blue-800 font-medium">
+            <Link to="/login" className="text-primary-500 hover:text-primary-400 font-medium">
               Sign in
             </Link>
           </p>


### PR DESCRIPTION
## Summary
- restyle the chat input footer with dark backgrounds and primary accent focus states
- convert the navbar to the shared dark palette and keep sticky behavior intact
- update login, register, and onboarding flows to use the dark surface and input styles for consistency

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68cccec32b008326b74ae375321b43a6