### PR TITLE
Enhance dashboard interactions and transaction APIs

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,24 +2,32 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     // Users can only read their own data, but anyone can create a user.
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function isOwner(userIdField) {
+      return isSignedIn() && request.auth.uid == userIdField;
+    }
+
     match /users/{userId} {
-      allow read, update, delete: if request.auth != null && request.auth.uid == userId;
-      allow create: if request.auth != null;
+      allow read, update, delete: if isOwner(userId);
+      allow create: if isSignedIn() && request.resource.data.user_id == request.auth.uid;
     }
 
     // Users can only read and write their own chat sessions.
     match /chat_sessions/{sessionId} {
-      allow read, write: if request.auth != null && request.auth.uid == resource.data.user_id;
+      allow read, write: if isOwner(resource.data.user_id) || (request.resource != null && isOwner(request.resource.data.user_id));
     }
 
     // Users can only access their own AP2 transactions
     match /ap2_transactions/{transactionId} {
-      allow read, write: if request.auth != null && request.auth.uid == resource.data.user_id;
+      allow read, write: if isOwner(resource.data.user_id) || (request.resource != null && isOwner(request.resource.data.user_id));
     }
 
     // Users can only access their own agent state
     match /agent_state/{stateId} {
-      allow read, write: if request.auth != null && request.auth.uid == resource.data.user_id;
+      allow read, write: if isOwner(resource.data.user_id) || (request.resource != null && isOwner(request.resource.data.user_id));
     }
 
     // Health checks can be read by anyone for system monitoring

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -100,3 +100,46 @@ export async function fetchChatSession(sessionId: string) {
     messages,
   } satisfies ChatSessionDetail;
 }
+
+export interface MandateResponse {
+  success?: boolean;
+  mandate?: any;
+  message?: string;
+  execution_result?: any;
+}
+
+export async function approveMandate(mandateId: string) {
+  const { data } = await api.post<MandateResponse>(`/api/ap2/mandates/${mandateId}/approve`);
+  return data;
+}
+
+export async function executeMandate(mandateId: string) {
+  const { data } = await api.post<MandateResponse>(`/api/ap2/mandates/${mandateId}/execute`);
+  return data;
+}
+
+export async function cancelMandate(mandateId: string) {
+  const { data } = await api.post<MandateResponse>(`/api/ap2/mandates/${mandateId}/cancel`);
+  return data;
+}
+
+export interface TransactionPayload {
+  amount: number;
+  description: string;
+  date: string;
+}
+
+export async function createDeposit(payload: TransactionPayload) {
+  const { data } = await api.post("/me/transactions/deposits", payload);
+  return data as { transaction: any; total_balance?: number };
+}
+
+export async function createPurchase(payload: TransactionPayload) {
+  const { data } = await api.post("/me/transactions/purchases", payload);
+  return data as { transaction: any; total_balance?: number };
+}
+
+export async function categorizeTransaction(payload: { category_key: string; category: string }) {
+  const { data } = await api.post("/me/transactions/categorize", payload);
+  return data as { category_key: string; category: string; persisted: boolean };
+}

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -2,6 +2,7 @@
 import { ReactNode } from "react";
 import { Navigate } from "react-router-dom";
 import { useAuth } from "@/context/Auth";
+import { Skeleton, SkeletonGroup } from "./Skeleton";
 
 interface ProtectedRouteProps {
   children: ReactNode;
@@ -14,10 +15,14 @@ export default function ProtectedRoute({ children, requiresNessie = false, requi
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center">
-        <div className="bg-white rounded-2xl shadow-xl p-8 text-center">
-          <div className="w-8 h-8 border-4 border-blue-600 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
-          <p className="text-black">Loading...</p>
+      <div className="min-h-screen bg-dark-100 flex items-center justify-center px-4">
+        <div className="w-full max-w-md bg-dark-200 border border-dark-400 rounded-2xl shadow-xl p-8 space-y-6">
+          <div className="space-y-3">
+            <Skeleton className="h-6 w-32" />
+            <Skeleton className="h-4 w-48" />
+          </div>
+          <SkeletonGroup count={3} itemClassName="h-12 w-full bg-dark-300/70" />
+          <Skeleton className="h-10 w-full bg-dark-300/70" />
         </div>
       </div>
     );

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,27 @@
+// src/components/Skeleton.tsx
+import clsx from "clsx";
+
+interface SkeletonProps {
+  className?: string;
+}
+
+export function Skeleton({ className }: SkeletonProps) {
+  return <div className={clsx("animate-pulse bg-dark-400/60 rounded", className)} />;
+}
+
+interface SkeletonGroupProps {
+  count: number;
+  className?: string;
+  itemClassName?: string;
+}
+
+export function SkeletonGroup({ count, className, itemClassName }: SkeletonGroupProps) {
+  return (
+    <div className={clsx("space-y-3", className)}>
+      {Array.from({ length: count }).map((_, index) => (
+        <Skeleton key={index} className={itemClassName} />
+      ))}
+    </div>
+  );
+}
+

--- a/src/pages/AdminPortalPage.tsx
+++ b/src/pages/AdminPortalPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { listUsers, updateUserRole, deleteUser } from "@/api/auth";
 import { useAuth } from "@/context/Auth";
 import toast from "react-hot-toast";
+import { SkeletonGroup } from "@/components/Skeleton";
 
 interface ManagedUser {
   id: string;
@@ -64,78 +65,80 @@ export default function AdminPortalPage() {
   const totalAdmins = useMemo(() => users.filter(u => (u.role || "user") === "admin").length, [users]);
 
   return (
-    <div className="min-h-screen bg-white text-black">
-      <div className="max-w-5xl mx-auto px-4 py-12">
-        <div className="mb-10">
-          <h1 className="text-3xl font-bold text-black">Admin Portal</h1>
-          <p className="text-black mt-2">
+    <div className="min-h-screen bg-dark-100 text-white">
+      <div className="max-w-5xl mx-auto px-4 py-12 space-y-10">
+        <div>
+          <h1 className="text-3xl font-bold">Admin Portal</h1>
+          <p className="text-dark-900 mt-2">
             Manage user accounts, promote trusted members, and keep your admin roster healthy.
           </p>
         </div>
 
-        <div className="grid md:grid-cols-3 gap-6 mb-10">
-          <div className="border border-gray-200 rounded-xl p-6 bg-white shadow-sm">
-            <p className="text-sm uppercase tracking-wide text-black">Total Users</p>
-            <p className="text-3xl font-semibold text-black mt-2">{users.length}</p>
+        <div className="grid md:grid-cols-3 gap-6">
+          <div className="border border-dark-400 rounded-xl p-6 bg-dark-200 shadow-lg">
+            <p className="text-sm uppercase tracking-wide text-dark-800">Total Users</p>
+            <p className="text-3xl font-semibold text-white mt-2">{users.length}</p>
           </div>
-          <div className="border border-gray-200 rounded-xl p-6 bg-white shadow-sm">
-            <p className="text-sm uppercase tracking-wide text-black">Administrators</p>
-            <p className="text-3xl font-semibold text-black mt-2">{totalAdmins}</p>
+          <div className="border border-dark-400 rounded-xl p-6 bg-dark-200 shadow-lg">
+            <p className="text-sm uppercase tracking-wide text-dark-800">Administrators</p>
+            <p className="text-3xl font-semibold text-white mt-2">{totalAdmins}</p>
           </div>
-          <div className="border border-gray-200 rounded-xl p-6 bg-white shadow-sm">
-            <p className="text-sm uppercase tracking-wide text-black">Active Session</p>
-            <p className="text-3xl font-semibold text-black mt-2">{user?.email}</p>
+          <div className="border border-dark-400 rounded-xl p-6 bg-dark-200 shadow-lg">
+            <p className="text-sm uppercase tracking-wide text-dark-800">Active Session</p>
+            <p className="text-3xl font-semibold text-white mt-2 truncate">{user?.email}</p>
           </div>
         </div>
 
-        <div className="border border-gray-200 rounded-2xl bg-white shadow-sm overflow-hidden">
-          <div className="px-6 py-4 border-b border-gray-200 bg-gray-50 text-black">
+        <div className="border border-dark-400 rounded-2xl bg-dark-200 shadow-lg overflow-hidden">
+          <div className="px-6 py-4 border-b border-dark-400 bg-dark-300 text-white">
             <h2 className="text-xl font-semibold">User Directory</h2>
           </div>
 
           {loading ? (
-            <div className="p-6 text-center text-black">Loading users...</div>
+            <div className="p-6">
+              <SkeletonGroup count={4} itemClassName="h-12 w-full bg-dark-300/70" />
+            </div>
           ) : users.length === 0 ? (
-            <div className="p-6 text-center text-black">No users found.</div>
+            <div className="p-6 text-center text-dark-900">No users found.</div>
           ) : (
             <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200 text-left text-black">
-                <thead className="bg-white">
+              <table className="min-w-full divide-y divide-dark-400 text-left">
+                <thead className="bg-dark-300">
                   <tr>
-                    <th className="px-6 py-3 text-xs font-semibold uppercase tracking-wide">Name</th>
-                    <th className="px-6 py-3 text-xs font-semibold uppercase tracking-wide">Email</th>
-                    <th className="px-6 py-3 text-xs font-semibold uppercase tracking-wide">Role</th>
-                    <th className="px-6 py-3 text-xs font-semibold uppercase tracking-wide">Actions</th>
+                    <th className="px-6 py-3 text-xs font-semibold uppercase tracking-wide text-dark-800">Name</th>
+                    <th className="px-6 py-3 text-xs font-semibold uppercase tracking-wide text-dark-800">Email</th>
+                    <th className="px-6 py-3 text-xs font-semibold uppercase tracking-wide text-dark-800">Role</th>
+                    <th className="px-6 py-3 text-xs font-semibold uppercase tracking-wide text-dark-800">Actions</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-200">
+                <tbody className="divide-y divide-dark-400">
                   {users.map(u => {
                     const fullName = [u.first_name, u.last_name].filter(Boolean).join(" ") || "—";
                     const isCurrentUser = u.id === user?.id;
                     const currentRole = (u.role || "user") as "user" | "admin";
 
                     return (
-                      <tr key={u.id} className="bg-white">
-                        <td className="px-6 py-4 text-sm font-medium text-black">{fullName}</td>
-                        <td className="px-6 py-4 text-sm text-black">{u.email}</td>
-                        <td className="px-6 py-4 text-sm text-black">
+                      <tr key={u.id} className="bg-dark-200">
+                        <td className="px-6 py-4 text-sm font-medium text-white">{fullName}</td>
+                        <td className="px-6 py-4 text-sm text-dark-800">{u.email}</td>
+                        <td className="px-6 py-4 text-sm text-white">
                           <select
                             value={currentRole}
                             onChange={event => handleRoleChange(u.id, event.target.value as "user" | "admin")}
                             disabled={savingId === u.id || (isCurrentUser && totalAdmins === 1)}
-                            className="border border-gray-300 rounded-lg px-3 py-2 text-sm text-black bg-white"
+                            className="border border-dark-500 rounded-lg px-3 py-2 text-sm bg-dark-300 text-white focus:outline-none focus:ring-2 focus:ring-primary-500"
                           >
                             <option value="user">User</option>
                             <option value="admin">Admin</option>
                           </select>
                         </td>
-                        <td className="px-6 py-4 text-sm text-black">
+                        <td className="px-6 py-4 text-sm text-white">
                           <div className="flex items-center gap-3">
                             <button
                               type="button"
                               onClick={() => handleRoleChange(u.id, currentRole)}
                               disabled={savingId === u.id}
-                              className="px-3 py-1 rounded-lg border border-gray-300 text-black hover:bg-gray-100 disabled:opacity-60"
+                              className="px-3 py-1 rounded-lg border border-dark-500 text-white hover:bg-dark-300 disabled:opacity-60"
                             >
                               {savingId === u.id ? "Saving..." : "Refresh"}
                             </button>
@@ -144,7 +147,7 @@ export default function AdminPortalPage() {
                                 type="button"
                                 onClick={() => handleDelete(u.id)}
                                 disabled={removingId === u.id}
-                                className="px-3 py-1 rounded-lg border border-red-400 text-black hover:bg-red-50 disabled:opacity-60"
+                                className="px-3 py-1 rounded-lg border border-red-400 text-red-300 hover:bg-red-500/10 disabled:opacity-60"
                               >
                                 {removingId === u.id ? "Removing..." : "Remove"}
                               </button>

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -13,7 +13,7 @@ import QuickChips from "@/components/QuickChips";
 import SourceCard from "@/components/SourceCard";
 import { MessageCircle, Sparkles, Send, Plus, Loader2 } from "lucide-react";
 import toast from "react-hot-toast";
-import { Link } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "@/context/Auth";
 
 const WELCOME_MESSAGE: ChatMsg = {
@@ -44,6 +44,8 @@ export default function ChatPage() {
   const { user } = useAuth();
   const isAuthenticated = Boolean(user);
 
+  const location = useLocation();
+  const nav = useNavigate();
   const [sessions, setSessions] = useState<ChatSessionSummary[]>([]);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
   const [messages, setMessages] = useState<ChatMsg[]>([WELCOME_MESSAGE]);
@@ -69,6 +71,14 @@ export default function ChatPage() {
       toast.error("Unable to load saved conversations");
     });
   }, [isAuthenticated]);
+
+  useEffect(() => {
+    const state = location.state as { prefillPrompt?: string } | null;
+    if (state?.prefillPrompt) {
+      setInput(state.prefillPrompt);
+      nav(location.pathname, { replace: true });
+    }
+  }, [location, nav]);
 
   useEffect(() => {
     const container = listRef.current;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,23 +1,145 @@
 // src/pages/Dashboard.tsx
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { FormEvent } from "react";
 import { mySummary, logout } from "@/api/auth";
 import { useAuth } from "@/context/Auth";
 import { useNavigate } from "react-router-dom";
-import { Download, TrendingUp, TrendingDown, Calendar, DollarSign, PieChart, BarChart3 } from "lucide-react";
+import {
+  Download,
+  TrendingUp,
+  TrendingDown,
+  Calendar,
+  DollarSign,
+  PieChart,
+  BarChart3,
+  ArrowDownRight,
+  ArrowUpRight,
+  Sparkles,
+  Loader2,
+} from "lucide-react";
 import toast from "react-hot-toast";
+import { Skeleton, SkeletonGroup } from "@/components/Skeleton";
+import { categorizeTransaction, createDeposit, createPurchase, type TransactionPayload } from "@/api/client";
 
 interface SummaryData {
   total_balance: number;
   accounts: any[];
   recent_transactions: any[];
   customer_id: string;
+  user_categories?: Record<string, string>;
+  ap2_summary?: {
+    active_count: number;
+    pending_count: number;
+    estimated_savings: number;
+  };
 }
+
+const CATEGORY_OPTIONS = [
+  "Groceries",
+  "Transportation",
+  "Housing",
+  "Utilities",
+  "Healthcare",
+  "Entertainment",
+  "Food & Dining",
+  "Savings",
+  "Income",
+  "Other",
+];
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value || 0);
 
 export default function Dashboard() {
   const [summary, setSummary] = useState<SummaryData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [selectedTransaction, setSelectedTransaction] = useState<any | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [transactionCategories, setTransactionCategories] = useState<Record<string, string>>({});
+  const [categoryDraft, setCategoryDraft] = useState("");
+  const [categorySaving, setCategorySaving] = useState(false);
+  const [showDepositModal, setShowDepositModal] = useState(false);
+  const [showPurchaseModal, setShowPurchaseModal] = useState(false);
+  const [actionLoading, setActionLoading] = useState<"deposit" | "purchase" | null>(null);
+  const [depositForm, setDepositForm] = useState(() => ({
+    amount: "",
+    description: "",
+    date: new Date().toISOString().slice(0, 10),
+  }));
+  const [purchaseForm, setPurchaseForm] = useState(() => ({
+    amount: "",
+    description: "",
+    date: new Date().toISOString().slice(0, 10),
+  }));
+  const [displayBalance, setDisplayBalance] = useState(0);
+  const animationFrameRef = useRef<number>();
+  const previousBalanceRef = useRef(0);
+  const hasInitialBalanceRef = useRef(false);
   const { user, setUser } = useAuth();
   const nav = useNavigate();
+
+  const inferCategory = useCallback(
+    (transaction: any) => {
+      if (!transaction) return "Other";
+      const key = transaction.category_key || "";
+      const saved = key ? transactionCategories[key] : undefined;
+      if (saved) {
+        return saved;
+      }
+
+      if (transaction.transaction_date) {
+        return "Income";
+      }
+
+      const description = (transaction.description || "").toLowerCase();
+      if (description.includes("grocery") || description.includes("h-e-b")) {
+        return "Groceries";
+      }
+      if (description.includes("gas") || description.includes("shell")) {
+        return "Transportation";
+      }
+      if (description.includes("coffee") || description.includes("starbucks")) {
+        return "Food & Dining";
+      }
+      if (description.includes("pharmacy") || description.includes("cvs")) {
+        return "Healthcare";
+      }
+      if (description.includes("uber") || description.includes("ride")) {
+        return "Transportation";
+      }
+      if (description.includes("metro") || description.includes("transit")) {
+        return "Transportation";
+      }
+      if (description.includes("utility") || description.includes("electric")) {
+        return "Utilities";
+      }
+      if (description.includes("rent") || description.includes("mortgage") || description.includes("lease")) {
+        return "Housing";
+      }
+
+      return "Other";
+    },
+    [transactionCategories]
+  );
+
+  const loadSummary = useCallback(async ({ showSkeleton = false } = {}) => {
+    if (showSkeleton) {
+      setLoading(true);
+    }
+    try {
+      const data = await mySummary();
+      setSummary(data);
+      setTransactionCategories(data.user_categories || {});
+    } catch (error: any) {
+      if (error?.response?.data?.error === "no_nessie_customer") {
+        nav("/onboarding");
+      } else {
+        toast.error("Failed to load dashboard data");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [nav]);
 
   useEffect(() => {
     if (!user) {
@@ -30,23 +152,60 @@ export default function Dashboard() {
       return;
     }
 
-    loadSummary();
-  }, [user, nav]);
+    loadSummary({ showSkeleton: true });
+  }, [user, nav, loadSummary]);
 
-  const loadSummary = async () => {
-    try {
-      const data = await mySummary();
-      setSummary(data);
-    } catch (error: any) {
-      if (error?.response?.data?.error === "no_nessie_customer") {
-        nav("/onboarding");
-      } else {
-        toast.error("Failed to load dashboard data");
-      }
-    } finally {
-      setLoading(false);
+  useEffect(() => {
+    if (!selectedTransaction) {
+      setCategoryDraft("");
+      return;
     }
-  };
+    setCategoryDraft(inferCategory(selectedTransaction));
+  }, [selectedTransaction, inferCategory]);
+
+  useEffect(() => {
+    if (!summary) return;
+
+    const target = summary.total_balance || 0;
+    if (!hasInitialBalanceRef.current) {
+      setDisplayBalance(target);
+      previousBalanceRef.current = target;
+      hasInitialBalanceRef.current = true;
+      return;
+    }
+
+    const start = previousBalanceRef.current;
+    const diff = target - start;
+    const duration = 700;
+    const startTime = performance.now();
+
+    if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current);
+    }
+
+    const animate = (time: number) => {
+      const elapsed = time - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setDisplayBalance(start + diff * eased);
+
+      if (progress < 1) {
+        animationFrameRef.current = requestAnimationFrame(animate);
+      } else {
+        previousBalanceRef.current = target;
+      }
+    };
+
+    animationFrameRef.current = requestAnimationFrame(animate);
+  }, [summary]);
+
+  useEffect(() => {
+    return () => {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, []);
 
   const handleLogout = async () => {
     try {
@@ -66,16 +225,19 @@ export default function Dashboard() {
 
   const calculateIncomeVsExpenses = () => {
     if (!summary?.recent_transactions) return { income: 0, expenses: 0 };
-    
+
     let income = 0;
     let expenses = 0;
-    
+
     // Get current month's transactions
     const currentMonth = new Date().getMonth();
     const currentYear = new Date().getFullYear();
-    
+
     summary.recent_transactions.forEach(transaction => {
-      const transactionDate = new Date(transaction.transaction_date || transaction.purchase_date);
+      const rawDate = transaction.transaction_date || transaction.purchase_date;
+      if (!rawDate) return;
+      const transactionDate = new Date(rawDate);
+      if (Number.isNaN(transactionDate.getTime())) return;
       if (transactionDate.getMonth() === currentMonth && transactionDate.getFullYear() === currentYear) {
         if (transaction.transaction_date) { // Deposit
           income += transaction.amount;
@@ -84,42 +246,36 @@ export default function Dashboard() {
         }
       }
     });
-    
+
     return { income, expenses };
   };
 
-  const getSpendingByCategory = () => {
-    if (!summary?.recent_transactions) return [];
-    
-    const categories: { [key: string]: number } = {};
-    
+  const { spendingByCategory, transactionsByCategory } = useMemo(() => {
+    if (!summary?.recent_transactions) {
+      return { spendingByCategory: [], transactionsByCategory: {} as Record<string, any[]> };
+    }
+
+    const categories: Record<string, number> = {};
+    const transactionMap: Record<string, any[]> = {};
+
     summary.recent_transactions.forEach(transaction => {
-      if (transaction.purchase_date) { // Only purchases
-        const description = transaction.description.toLowerCase();
-        let category = "Other";
-        
-        if (description.includes("grocery") || description.includes("h-e-b")) {
-          category = "Groceries";
-        } else if (description.includes("gas") || description.includes("shell")) {
-          category = "Transportation";
-        } else if (description.includes("coffee") || description.includes("starbucks")) {
-          category = "Food & Dining";
-        } else if (description.includes("pharmacy") || description.includes("cvs")) {
-          category = "Healthcare";
-        } else if (description.includes("uber") || description.includes("ride")) {
-          category = "Transportation";
-        } else if (description.includes("metro") || description.includes("transit")) {
-          category = "Transportation";
-        } else if (description.includes("utility") || description.includes("electric")) {
-          category = "Utilities";
-        }
-        
+      const category = inferCategory(transaction);
+      if (!category) return;
+
+      if (!transactionMap[category]) {
+        transactionMap[category] = [];
+      }
+      transactionMap[category].push(transaction);
+
+      if (transaction.purchase_date) {
         categories[category] = (categories[category] || 0) + transaction.amount;
       }
     });
-    
-    return Object.entries(categories).map(([name, amount]) => ({ name, amount }));
-  };
+
+    const formattedCategories = Object.entries(categories).map(([name, amount]) => ({ name, amount }));
+
+    return { spendingByCategory: formattedCategories, transactionsByCategory: transactionMap };
+  }, [summary, inferCategory]);
 
   const get30DayBalance = () => {
     // Mock balance line data for 30 days
@@ -145,42 +301,251 @@ export default function Dashboard() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <div className="bg-white rounded-2xl shadow-xl p-8 text-center">
-          <div className="w-8 h-8 border-4 border-blue-600 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
-          <p className="text-gray-600">Loading your dashboard...</p>
+      <div className="min-h-[calc(100vh-8rem)] bg-dark-100 flex items-center justify-center px-6 py-12">
+        <div className="w-full max-w-6xl space-y-6">
+          <div className="bg-dark-200 border border-dark-400 rounded-2xl p-6 shadow-xl space-y-4">
+            <Skeleton className="h-6 w-48" />
+            <Skeleton className="h-4 w-64" />
+            <SkeletonGroup count={3} itemClassName="h-12 w-full bg-dark-300/70" />
+          </div>
+          <div className="grid lg:grid-cols-2 gap-6">
+            <Skeleton className="h-56 w-full bg-dark-200 border border-dark-400 rounded-2xl" />
+            <Skeleton className="h-56 w-full bg-dark-200 border border-dark-400 rounded-2xl" />
+          </div>
         </div>
       </div>
     );
   }
 
+  const largestPurchase = useMemo(() => {
+    if (!summary?.recent_transactions) return null;
+    return summary.recent_transactions
+      .filter(transaction => transaction.purchase_date)
+      .reduce((max: any, transaction: any) => {
+        if (!max || transaction.amount > max.amount) {
+          return transaction;
+        }
+        return max;
+      }, null as any);
+  }, [summary?.recent_transactions]);
+
+  const largestDeposit = useMemo(() => {
+    if (!summary?.recent_transactions) return null;
+    return summary.recent_transactions
+      .filter(transaction => transaction.transaction_date)
+      .reduce((max: any, transaction: any) => {
+        if (!max || transaction.amount > max.amount) {
+          return transaction;
+        }
+        return max;
+      }, null as any);
+  }, [summary?.recent_transactions]);
+
+  const spendingTrend = useMemo(() => {
+    if (!summary?.recent_transactions) return null;
+
+    const now = new Date();
+    const currentMonth = now.getMonth();
+    const currentYear = now.getFullYear();
+    const previous = new Date(currentYear, currentMonth - 1, 1);
+    const previousMonth = previous.getMonth();
+    const previousYear = previous.getFullYear();
+
+    let currentSpending = 0;
+    let previousSpending = 0;
+
+    summary.recent_transactions.forEach(transaction => {
+      if (!transaction.purchase_date) return;
+      const dateValue = new Date(transaction.purchase_date);
+      if (Number.isNaN(dateValue.getTime())) return;
+
+      if (dateValue.getFullYear() === currentYear && dateValue.getMonth() === currentMonth) {
+        currentSpending += transaction.amount;
+      } else if (dateValue.getFullYear() === previousYear && dateValue.getMonth() === previousMonth) {
+        previousSpending += transaction.amount;
+      }
+    });
+
+    let percentage = 0;
+    let direction: "up" | "down" | "flat" = "flat";
+    if (previousSpending > 0) {
+      const change = ((currentSpending - previousSpending) / previousSpending) * 100;
+      if (change > 0.5) {
+        direction = "up";
+        percentage = change;
+      } else if (change < -0.5) {
+        direction = "down";
+        percentage = Math.abs(change);
+      }
+    }
+
+    return {
+      current: currentSpending,
+      previous: previousSpending,
+      direction,
+      percentage,
+    };
+  }, [summary?.recent_transactions]);
+
+  const ap2Summary = summary?.ap2_summary || {
+    active_count: 0,
+    pending_count: 0,
+    estimated_savings: 0,
+  };
+
   const { income, expenses } = calculateIncomeVsExpenses();
-  const spendingByCategory = getSpendingByCategory();
   const balanceData = get30DayBalance();
+  const filteredTransactions = useMemo(() => {
+    if (!summary?.recent_transactions) return [] as any[];
+    if (!selectedCategory) return summary.recent_transactions;
+    return transactionsByCategory[selectedCategory] || [];
+  }, [summary?.recent_transactions, selectedCategory, transactionsByCategory]);
+
+  const handleSubmitDeposit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const amount = parseFloat(depositForm.amount);
+    if (Number.isNaN(amount) || amount <= 0) {
+      toast.error("Enter a positive deposit amount");
+      return;
+    }
+
+    const payload: TransactionPayload = {
+      amount,
+      description: depositForm.description || "Deposit",
+      date: depositForm.date,
+    };
+
+    setActionLoading("deposit");
+    try {
+      const { transaction, total_balance } = await createDeposit(payload);
+      if (!transaction) {
+        throw new Error("Deposit failed to return transaction");
+      }
+      toast.success("Deposit recorded");
+      setShowDepositModal(false);
+      setDepositForm(() => ({ amount: "", description: "", date: new Date().toISOString().slice(0, 10) }));
+      setSummary(prev => {
+        if (!prev) return prev;
+        const updatedTransactions = [transaction, ...prev.recent_transactions].slice(0, 25);
+        const updatedBalance = typeof total_balance === "number" ? total_balance : prev.total_balance + amount;
+        return { ...prev, recent_transactions: updatedTransactions, total_balance: updatedBalance };
+      });
+      if (transaction.category_key) {
+        setTransactionCategories(prev => ({
+          ...prev,
+          [transaction.category_key]: inferCategory(transaction),
+        }));
+      }
+      loadSummary();
+    } catch (error: any) {
+      console.error(error);
+      toast.error(error?.response?.data?.error || "Failed to add deposit");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleSubmitPurchase = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const amount = parseFloat(purchaseForm.amount);
+    if (Number.isNaN(amount) || amount <= 0) {
+      toast.error("Enter a positive purchase amount");
+      return;
+    }
+
+    const payload: TransactionPayload = {
+      amount,
+      description: purchaseForm.description || "Purchase",
+      date: purchaseForm.date,
+    };
+
+    setActionLoading("purchase");
+    try {
+      const { transaction, total_balance } = await createPurchase(payload);
+      if (!transaction) {
+        throw new Error("Purchase failed to return transaction");
+      }
+      toast.success("Purchase added");
+      setShowPurchaseModal(false);
+      setPurchaseForm(() => ({ amount: "", description: "", date: new Date().toISOString().slice(0, 10) }));
+      setSummary(prev => {
+        if (!prev) return prev;
+        const updatedTransactions = [transaction, ...prev.recent_transactions].slice(0, 25);
+        const updatedBalance = typeof total_balance === "number" ? total_balance : prev.total_balance - amount;
+        return { ...prev, recent_transactions: updatedTransactions, total_balance: updatedBalance };
+      });
+      if (transaction.category_key) {
+        setTransactionCategories(prev => ({
+          ...prev,
+          [transaction.category_key]: inferCategory(transaction),
+        }));
+      }
+      loadSummary();
+    } catch (error: any) {
+      console.error(error);
+      toast.error(error?.response?.data?.error || "Failed to add purchase");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleSaveCategory = async () => {
+    if (!selectedTransaction) return;
+    const trimmed = categoryDraft.trim();
+    if (!trimmed) {
+      toast.error("Enter a category name");
+      return;
+    }
+    if (!selectedTransaction.category_key) {
+      toast.error("Unable to categorize this transaction");
+      return;
+    }
+
+    setCategorySaving(true);
+    try {
+      await categorizeTransaction({ category_key: selectedTransaction.category_key, category: trimmed });
+      setTransactionCategories(prev => ({ ...prev, [selectedTransaction.category_key]: trimmed }));
+      toast.success("Category saved");
+    } catch (error: any) {
+      console.error(error);
+      toast.error(error?.response?.data?.error || "Failed to save category");
+    } finally {
+      setCategorySaving(false);
+    }
+  };
+
+  const handleAskAIAboutTransaction = () => {
+    if (!selectedTransaction) return;
+    const merchant = selectedTransaction.description || "this transaction";
+    const when = selectedTransaction.transaction_date || selectedTransaction.purchase_date;
+    const prompt = `Tell me about my spending habits related to this transaction at ${merchant}${when ? ` on ${when}` : ""}.`;
+    setSelectedTransaction(null);
+    nav("/chat", { state: { prefillPrompt: prompt } });
+  };
 
   return (
-    <div className="bg-gradient-to-br from-blue-50 to-indigo-100 p-4 min-h-[calc(100vh-8rem)]">
+    <div className="bg-dark-100 min-h-[calc(100vh-8rem)] p-4">
       <div className="max-w-7xl mx-auto space-y-6">
         {/* Header */}
-        <div className="bg-white rounded-2xl shadow-xl p-6">
+        <div className="bg-dark-200 border border-dark-400 rounded-2xl shadow-xl p-6">
           <div className="flex justify-between items-center">
             <div>
-              <h1 className="text-3xl font-bold text-gray-900">
+              <h1 className="text-3xl font-bold text-white">
                 Welcome back, {user?.first_name || user?.email}!
               </h1>
-              <p className="text-gray-600 mt-1">Here's your financial overview</p>
+              <p className="text-dark-900 mt-1">Here's your financial overview</p>
             </div>
             <div className="flex space-x-3">
               <button
                 onClick={exportToSheets}
-                className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg transition-colors flex items-center space-x-2"
+                className="px-4 py-2 bg-emerald-500 hover:bg-emerald-600 text-white rounded-lg transition-colors flex items-center space-x-2"
               >
                 <Download className="h-4 w-4" />
                 <span>Export to Sheets</span>
               </button>
               <button
                 onClick={handleLogout}
-                className="px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg transition-colors"
+                className="px-4 py-2 bg-dark-300 hover:bg-dark-400 text-dark-900 rounded-lg transition-colors"
               >
                 Logout
               </button>
@@ -189,44 +554,112 @@ export default function Dashboard() {
         </div>
 
         {/* Total Balance Card */}
-        <div className="bg-gradient-to-r from-blue-600 to-indigo-600 rounded-2xl shadow-xl p-8 text-white">
+        <div className="bg-gradient-to-r from-primary-600 to-primary-700 rounded-2xl shadow-xl p-8 text-white border border-dark-400">
           <div className="flex items-center justify-between">
             <div>
               <h2 className="text-xl font-semibold mb-2">Total Balance</h2>
-              <p className="text-4xl font-bold">${summary?.total_balance?.toFixed(2) || "0.00"}</p>
-              <p className="text-blue-100 mt-2">Across all your accounts</p>
+              <p className="text-4xl font-bold transition-all duration-500">{formatCurrency(displayBalance)}</p>
+              <p className="text-primary-100 mt-2">Across all your accounts</p>
             </div>
-            <DollarSign className="h-16 w-16 text-blue-200" />
+            <DollarSign className="h-16 w-16 text-primary-100" />
+          </div>
+        </div>
+
+        {/* Key Insights */}
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          <div className="bg-dark-200 border border-dark-400 rounded-2xl shadow-xl p-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-dark-700">Largest Purchase</p>
+                <h4 className="text-2xl font-semibold text-accent-red mt-2">
+                  {largestPurchase ? formatCurrency(-largestPurchase.amount) : "—"}
+                </h4>
+              </div>
+              <div className="h-12 w-12 rounded-full bg-accent-red/10 flex items-center justify-center">
+                <ArrowDownRight className="h-6 w-6 text-accent-red" />
+              </div>
+            </div>
+            <p className="text-sm text-dark-900 mt-3">
+              {largestPurchase
+                ? `${largestPurchase.description} on ${largestPurchase.purchase_date}`
+                : "We haven't seen any purchases this month."}
+            </p>
+          </div>
+
+          <div className="bg-dark-200 border border-dark-400 rounded-2xl shadow-xl p-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-dark-700">Largest Deposit</p>
+                <h4 className="text-2xl font-semibold text-emerald-300 mt-2">
+                  {largestDeposit ? formatCurrency(largestDeposit.amount) : "—"}
+                </h4>
+              </div>
+              <div className="h-12 w-12 rounded-full bg-emerald-500/10 flex items-center justify-center">
+                <ArrowUpRight className="h-6 w-6 text-emerald-300" />
+              </div>
+            </div>
+            <p className="text-sm text-dark-900 mt-3">
+              {largestDeposit
+                ? `${largestDeposit.description} on ${largestDeposit.transaction_date}`
+                : "Add a deposit to start tracking your income."}
+            </p>
+          </div>
+
+          <div className="bg-dark-200 border border-dark-400 rounded-2xl shadow-xl p-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-dark-700">Spending Trend</p>
+                <h4 className="text-2xl font-semibold text-white mt-2">
+                  {spendingTrend
+                    ? spendingTrend.direction === "flat"
+                      ? "Holding steady"
+                      : `${spendingTrend.direction === "up" ? "Up" : "Down"} ${spendingTrend.percentage.toFixed(1)}%`
+                    : "Not enough data"}
+                </h4>
+              </div>
+              <div className="h-12 w-12 rounded-full bg-primary-500/10 flex items-center justify-center">
+                <TrendingUp className="h-6 w-6 text-primary-300" />
+              </div>
+            </div>
+            <p className="text-sm text-dark-900 mt-3">
+              {spendingTrend
+                ? spendingTrend.direction === "flat"
+                  ? "You're spending about the same as last month."
+                  : spendingTrend.direction === "up"
+                    ? "Spending is higher than last month—keep an eye on your budget."
+                    : "Great work! You're spending less than last month."
+                : "We need two months of transactions to spot a trend."}
+            </p>
           </div>
         </div>
 
         {/* Income vs Expenses & Spending by Category */}
         <div className="grid lg:grid-cols-2 gap-6">
           {/* Income vs Expenses (This Month) */}
-          <div className="bg-white rounded-2xl shadow-xl p-6">
-            <h3 className="text-xl font-semibold text-gray-900 mb-4 flex items-center">
-              <BarChart3 className="h-5 w-5 mr-2 text-blue-600" />
+          <div className="bg-dark-200 border border-dark-400 rounded-2xl shadow-xl p-6">
+            <h3 className="text-xl font-semibold text-white mb-4 flex items-center">
+              <BarChart3 className="h-5 w-5 mr-2 text-primary-500" />
               Income vs Expenses (This Month)
             </h3>
             <div className="space-y-4">
-              <div className="flex items-center justify-between p-4 bg-green-50 rounded-lg">
+              <div className="flex items-center justify-between p-4 bg-emerald-500/10 rounded-lg">
                 <div className="flex items-center space-x-3">
-                  <TrendingUp className="h-6 w-6 text-green-600" />
-                  <span className="font-medium text-gray-900">Income</span>
+                  <TrendingUp className="h-6 w-6 text-emerald-400" />
+                  <span className="font-medium text-white">Income</span>
                 </div>
-                <span className="text-lg font-semibold text-green-600">+${income.toFixed(2)}</span>
+                <span className="text-lg font-semibold text-emerald-300">+${income.toFixed(2)}</span>
               </div>
-              <div className="flex items-center justify-between p-4 bg-red-50 rounded-lg">
+              <div className="flex items-center justify-between p-4 bg-accent-red/10 rounded-lg">
                 <div className="flex items-center space-x-3">
-                  <TrendingDown className="h-6 w-6 text-red-600" />
-                  <span className="font-medium text-gray-900">Expenses</span>
+                  <TrendingDown className="h-6 w-6 text-accent-red" />
+                  <span className="font-medium text-white">Expenses</span>
                 </div>
-                <span className="text-lg font-semibold text-red-600">-${expenses.toFixed(2)}</span>
+                <span className="text-lg font-semibold text-accent-red">-${expenses.toFixed(2)}</span>
               </div>
-              <div className="border-t pt-4">
+              <div className="border-t border-dark-400 pt-4">
                 <div className="flex items-center justify-between">
-                  <span className="font-semibold text-gray-900">Net Income</span>
-                  <span className={`text-lg font-bold ${income - expenses >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                  <span className="font-semibold text-white">Net Income</span>
+                  <span className={`text-lg font-bold ${income - expenses >= 0 ? 'text-emerald-300' : 'text-accent-red'}`}>
                     ${(income - expenses).toFixed(2)}
                   </span>
                 </div>
@@ -235,31 +668,37 @@ export default function Dashboard() {
           </div>
 
           {/* Spending by Category */}
-          <div className="bg-white rounded-2xl shadow-xl p-6">
-            <h3 className="text-xl font-semibold text-gray-900 mb-4 flex items-center">
-              <PieChart className="h-5 w-5 mr-2 text-purple-600" />
+          <div className="bg-dark-200 border border-dark-400 rounded-2xl shadow-xl p-6">
+            <h3 className="text-xl font-semibold text-white mb-4 flex items-center">
+              <PieChart className="h-5 w-5 mr-2 text-purple-400" />
               Spending by Category
             </h3>
             <div className="space-y-3">
               {spendingByCategory.map((category, index) => {
                 const colors = ['bg-blue-500', 'bg-green-500', 'bg-yellow-500', 'bg-purple-500', 'bg-pink-500', 'bg-indigo-500'];
                 const percentage = expenses > 0 ? (category.amount / expenses) * 100 : 0;
-                
+
                 return (
-                  <div key={category.name} className="flex items-center space-x-3">
+                  <button
+                    key={category.name}
+                    onClick={() => setSelectedCategory(prev => (prev === category.name ? null : category.name))}
+                    className={`flex items-center space-x-3 w-full text-left px-3 py-2 rounded-lg transition-colors ${
+                      selectedCategory === category.name ? 'bg-dark-300' : 'hover:bg-dark-300/70'
+                    }`}
+                  >
                     <div className={`w-3 h-3 rounded-full ${colors[index % colors.length]}`}></div>
                     <div className="flex-1 flex justify-between items-center">
-                      <span className="text-gray-700 font-medium">{category.name}</span>
+                      <span className="text-dark-900 font-medium">{category.name}</span>
                       <div className="text-right">
-                        <span className="text-gray-900 font-semibold">${category.amount.toFixed(2)}</span>
-                        <span className="text-sm text-gray-500 ml-2">({percentage.toFixed(1)}%)</span>
+                        <span className="text-white font-semibold">${category.amount.toFixed(2)}</span>
+                        <span className="text-sm text-dark-800 ml-2">({percentage.toFixed(1)}%)</span>
                       </div>
                     </div>
-                  </div>
+                  </button>
                 );
               })}
               {spendingByCategory.length === 0 && (
-                <p className="text-gray-500 text-center py-4">No spending data available</p>
+                <p className="text-dark-900 text-center py-4">No spending data available</p>
               )}
             </div>
           </div>
@@ -268,92 +707,380 @@ export default function Dashboard() {
         {/* Balance Line (30d) & Recent Transactions */}
         <div className="grid lg:grid-cols-2 gap-6">
           {/* Balance Line (30d) */}
-          <div className="bg-white rounded-2xl shadow-xl p-6">
-            <h3 className="text-xl font-semibold text-gray-900 mb-4 flex items-center">
-              <TrendingUp className="h-5 w-5 mr-2 text-green-600" />
+          <div className="bg-dark-200 border border-dark-400 rounded-2xl shadow-xl p-6">
+            <h3 className="text-xl font-semibold text-white mb-4 flex items-center">
+              <TrendingUp className="h-5 w-5 mr-2 text-emerald-400" />
               Balance Line (30 Days)
             </h3>
             <div className="h-40 flex items-end space-x-1">
               {balanceData.slice(-15).map((data, index) => {
                 const maxBalance = Math.max(...balanceData.map(d => d.balance));
                 const height = (data.balance / maxBalance) * 100;
-                
+
                 return (
                   <div key={index} className="flex-1 flex flex-col items-center">
-                    <div 
-                      className="bg-gradient-to-t from-blue-500 to-blue-300 rounded-sm w-full"
+                    <div
+                      className="bg-gradient-to-t from-primary-500 to-primary-300 rounded-sm w-full"
                       style={{ height: `${height}%`, minHeight: '4px' }}
                     ></div>
-                    <span className="text-xs text-gray-500 mt-1 transform rotate-45 origin-bottom-left">
+                    <span className="text-xs text-dark-800 mt-1 transform rotate-45 origin-bottom-left">
                       {data.date.split('/')[1]}/{data.date.split('/')[0]}
                     </span>
                   </div>
                 );
               })}
             </div>
-            <p className="text-sm text-gray-600 mt-2 text-center">
+            <p className="text-sm text-dark-900 mt-2 text-center">
               Current: ${balanceData[balanceData.length - 1]?.balance.toFixed(2)}
             </p>
           </div>
 
-          {/* Recent Transactions (10-25) */}
-          <div className="bg-white rounded-2xl shadow-xl p-6">
-            <h3 className="text-xl font-semibold text-gray-900 mb-4 flex items-center">
-              <Calendar className="h-5 w-5 mr-2 text-blue-600" />
-              Recent Transactions
-            </h3>
-            <div className="space-y-3 max-h-80 overflow-y-auto">
-              {summary?.recent_transactions?.slice(0, 25).map((transaction, index) => (
-                <div key={index} className="flex justify-between items-center py-2 px-3 border border-gray-100 rounded-lg hover:bg-gray-50 transition-colors">
+          {/* Recent Transactions (interactive) */}
+          <div className="bg-dark-200 border border-dark-400 rounded-2xl shadow-xl p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-xl font-semibold text-white flex items-center">
+                <Calendar className="h-5 w-5 mr-2 text-primary-500" />
+                Recent Transactions
+              </h3>
+              {selectedCategory && (
+                <button
+                  onClick={() => setSelectedCategory(null)}
+                  className="text-xs text-primary-300 hover:text-primary-200"
+                >
+                  Clear filter
+                </button>
+              )}
+            </div>
+            <div className="space-y-3 max-h-80 overflow-y-auto pr-1">
+              {filteredTransactions.slice(0, 25).map((transaction, index) => (
+                <button
+                  key={index}
+                  onClick={() => setSelectedTransaction(transaction)}
+                  className="w-full text-left flex justify-between items-center py-2 px-3 border border-dark-400 rounded-lg hover:bg-dark-300 transition-colors"
+                >
                   <div className="flex items-center space-x-3">
                     <div className={`w-2 h-2 rounded-full ${
-                      transaction.transaction_date ? 'bg-green-500' : 'bg-red-500'
+                      transaction.transaction_date ? 'bg-emerald-400' : 'bg-accent-red'
                     }`}></div>
                     <div>
-                      <p className="font-medium text-gray-900 text-sm">{transaction.description}</p>
-                      <p className="text-xs text-gray-600">
+                      <p className="font-medium text-white text-sm">{transaction.description}</p>
+                      <p className="text-xs text-dark-900">
                         {transaction.transaction_date || transaction.purchase_date}
                       </p>
                     </div>
                   </div>
                   <div className="text-right">
                     <p className={`font-semibold text-sm ${
-                      transaction.transaction_date ? "text-green-600" : "text-red-600"
+                      transaction.transaction_date ? "text-emerald-300" : "text-accent-red"
                     }`}>
                       {transaction.transaction_date ? "+" : "-"}${Math.abs(transaction.amount).toFixed(2)}
                     </p>
                   </div>
-                </div>
+                </button>
               ))}
-              {(!summary?.recent_transactions || summary.recent_transactions.length === 0) && (
-                <p className="text-gray-500 text-center py-8">No transactions found</p>
+              {filteredTransactions.length === 0 && (
+                <p className="text-dark-900 text-center py-8">No transactions found</p>
               )}
             </div>
           </div>
         </div>
 
+        {/* AP2 Automations Summary */}
+        <div className="bg-dark-200 border border-dark-400 rounded-2xl shadow-xl p-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div className="flex items-start gap-4">
+            <div className="h-12 w-12 rounded-full bg-purple-500/10 flex items-center justify-center">
+              <Sparkles className="h-6 w-6 text-purple-300" />
+            </div>
+            <div>
+              <h3 className="text-xl font-semibold text-white">Autonomous AP2 Automations</h3>
+              <p className="text-dark-900 mt-1">
+                You have <span className="text-white font-semibold">{ap2Summary.active_count}</span> active automations and
+                <span className="text-white font-semibold"> {ap2Summary.pending_count}</span> awaiting approval.
+                They're managing roughly {formatCurrency(ap2Summary.estimated_savings)} each month.
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={() => nav("/trust-agent")}
+            className="px-4 py-2 bg-purple-500/20 hover:bg-purple-500/30 text-purple-200 rounded-lg transition-colors"
+          >
+            Review automations
+          </button>
+        </div>
+
         {/* Quick Actions */}
-        <div className="bg-white rounded-2xl shadow-xl p-6">
-          <h3 className="text-xl font-semibold text-gray-900 mb-4">Quick Actions</h3>
+        <div className="bg-dark-200 border border-dark-400 rounded-2xl shadow-xl p-6">
+          <h3 className="text-xl font-semibold text-white mb-4">Quick Actions</h3>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <button className="p-4 bg-blue-50 hover:bg-blue-100 rounded-lg text-center transition-colors">
-              <div className="text-blue-600 font-semibold">View All Transactions</div>
+            <button className="p-4 bg-primary-500/10 hover:bg-primary-500/20 rounded-lg text-center transition-colors">
+              <div className="text-primary-300 font-semibold">View All Transactions</div>
             </button>
-            <button className="p-4 bg-green-50 hover:bg-green-100 rounded-lg text-center transition-colors">
-              <div className="text-green-600 font-semibold">Add Deposit</div>
-            </button>
-            <button className="p-4 bg-orange-50 hover:bg-orange-100 rounded-lg text-center transition-colors">
-              <div className="text-orange-600 font-semibold">Make Purchase</div>
-            </button>
-            <button 
-              onClick={() => nav("/chat")}
-              className="p-4 bg-purple-50 hover:bg-purple-100 rounded-lg text-center transition-colors"
+            <button
+              onClick={() => setShowDepositModal(true)}
+              className="p-4 bg-emerald-500/10 hover:bg-emerald-500/20 rounded-lg text-center transition-colors"
             >
-              <div className="text-purple-600 font-semibold">Ask AI Assistant</div>
+              <div className="text-emerald-300 font-semibold">Add Deposit</div>
+            </button>
+            <button
+              onClick={() => setShowPurchaseModal(true)}
+              className="p-4 bg-accent-gold/10 hover:bg-accent-gold/20 rounded-lg text-center transition-colors"
+            >
+              <div className="text-accent-gold font-semibold">Make Purchase</div>
+            </button>
+            <button
+              onClick={() => nav("/chat")}
+              className="p-4 bg-purple-500/10 hover:bg-purple-500/20 rounded-lg text-center transition-colors"
+            >
+              <div className="text-purple-300 font-semibold">Ask AI Assistant</div>
             </button>
           </div>
         </div>
       </div>
+
+      {showDepositModal && (
+        <div
+          className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center px-4 py-8 z-50"
+          onClick={() => setShowDepositModal(false)}
+        >
+          <form
+            onSubmit={handleSubmitDeposit}
+            onClick={event => event.stopPropagation()}
+            className="w-full max-w-md bg-dark-200 border border-dark-400 rounded-2xl shadow-2xl p-6 space-y-4"
+          >
+            <div className="flex justify-between items-center">
+              <h4 className="text-xl font-semibold text-white">Add a Deposit</h4>
+              <button
+                type="button"
+                onClick={() => setShowDepositModal(false)}
+                className="text-dark-900 hover:text-white"
+              >
+                Close
+              </button>
+            </div>
+            <div className="space-y-4">
+              <label className="block text-sm text-dark-800">
+                Amount
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={depositForm.amount}
+                  onChange={event => setDepositForm(prev => ({ ...prev, amount: event.target.value }))}
+                  className="mt-1 w-full px-4 py-3 border border-dark-400 bg-dark-300 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                  required
+                />
+              </label>
+              <label className="block text-sm text-dark-800">
+                Description
+                <input
+                  type="text"
+                  value={depositForm.description}
+                  onChange={event => setDepositForm(prev => ({ ...prev, description: event.target.value }))}
+                  placeholder="Paycheck, refund, etc."
+                  className="mt-1 w-full px-4 py-3 border border-dark-400 bg-dark-300 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                />
+              </label>
+              <label className="block text-sm text-dark-800">
+                Date
+                <input
+                  type="date"
+                  value={depositForm.date}
+                  onChange={event => setDepositForm(prev => ({ ...prev, date: event.target.value }))}
+                  className="mt-1 w-full px-4 py-3 border border-dark-400 bg-dark-300 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                  required
+                />
+              </label>
+            </div>
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setShowDepositModal(false)}
+                className="px-4 py-2 bg-dark-300 text-dark-900 rounded-lg hover:bg-dark-400"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={actionLoading === "deposit"}
+                className="px-4 py-2 bg-emerald-500 hover:bg-emerald-600 text-white rounded-lg flex items-center gap-2 disabled:opacity-70"
+              >
+                {actionLoading === "deposit" && <Loader2 className="h-4 w-4 animate-spin" />}Save Deposit
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {showPurchaseModal && (
+        <div
+          className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center px-4 py-8 z-50"
+          onClick={() => setShowPurchaseModal(false)}
+        >
+          <form
+            onSubmit={handleSubmitPurchase}
+            onClick={event => event.stopPropagation()}
+            className="w-full max-w-md bg-dark-200 border border-dark-400 rounded-2xl shadow-2xl p-6 space-y-4"
+          >
+            <div className="flex justify-between items-center">
+              <h4 className="text-xl font-semibold text-white">Log a Purchase</h4>
+              <button
+                type="button"
+                onClick={() => setShowPurchaseModal(false)}
+                className="text-dark-900 hover:text-white"
+              >
+                Close
+              </button>
+            </div>
+            <div className="space-y-4">
+              <label className="block text-sm text-dark-800">
+                Amount
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={purchaseForm.amount}
+                  onChange={event => setPurchaseForm(prev => ({ ...prev, amount: event.target.value }))}
+                  className="mt-1 w-full px-4 py-3 border border-dark-400 bg-dark-300 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-accent-gold"
+                  required
+                />
+              </label>
+              <label className="block text-sm text-dark-800">
+                Description
+                <input
+                  type="text"
+                  value={purchaseForm.description}
+                  onChange={event => setPurchaseForm(prev => ({ ...prev, description: event.target.value }))}
+                  placeholder="Merchant, memo, or notes"
+                  className="mt-1 w-full px-4 py-3 border border-dark-400 bg-dark-300 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-accent-gold"
+                />
+              </label>
+              <label className="block text-sm text-dark-800">
+                Date
+                <input
+                  type="date"
+                  value={purchaseForm.date}
+                  onChange={event => setPurchaseForm(prev => ({ ...prev, date: event.target.value }))}
+                  className="mt-1 w-full px-4 py-3 border border-dark-400 bg-dark-300 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-accent-gold"
+                  required
+                />
+              </label>
+            </div>
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setShowPurchaseModal(false)}
+                className="px-4 py-2 bg-dark-300 text-dark-900 rounded-lg hover:bg-dark-400"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={actionLoading === "purchase"}
+                className="px-4 py-2 bg-accent-gold/90 hover:bg-accent-gold text-dark-100 rounded-lg flex items-center gap-2 disabled:opacity-70"
+              >
+                {actionLoading === "purchase" && <Loader2 className="h-4 w-4 animate-spin" />}Save Purchase
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {selectedTransaction && (
+        <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center px-4 py-8 z-50">
+          <div className="w-full max-w-lg bg-dark-200 border border-dark-400 rounded-2xl shadow-2xl p-6 space-y-4">
+            <div className="flex justify-between items-center">
+              <h4 className="text-xl font-semibold text-white">Transaction Details</h4>
+              <button
+                onClick={() => setSelectedTransaction(null)}
+                className="text-dark-900 hover:text-white"
+              >
+                Close
+              </button>
+            </div>
+            <div className="space-y-3 text-sm text-dark-900">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-dark-700">Description</p>
+                <p className="text-white text-base">{selectedTransaction.description}</p>
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-dark-700">Amount</p>
+                  <p className={`text-lg font-semibold ${selectedTransaction.transaction_date ? 'text-emerald-300' : 'text-accent-red'}`}>
+                    {selectedTransaction.transaction_date ? "+" : "-"}${Math.abs(selectedTransaction.amount).toFixed(2)}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-dark-700">Type</p>
+                  <p className="text-white">{selectedTransaction.transaction_date ? "Deposit" : "Purchase"}</p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-dark-700">Date</p>
+                  <p className="text-white">{selectedTransaction.transaction_date || selectedTransaction.purchase_date}</p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-dark-700">Status</p>
+                  <p className="text-white">{selectedTransaction.status || "posted"}</p>
+                </div>
+              </div>
+              {selectedTransaction.merchant && (
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-dark-700">Merchant</p>
+                  <p className="text-white">{selectedTransaction.merchant?.name || selectedTransaction.merchant}</p>
+                </div>
+              )}
+              <div>
+                <p className="text-xs uppercase tracking-wide text-dark-700">Account</p>
+                <p className="text-white">{selectedTransaction.account_id || "Primary"}</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wide text-dark-700">Category</p>
+                <div className="mt-2 space-y-2">
+                  <select
+                    value={CATEGORY_OPTIONS.includes(categoryDraft) ? categoryDraft : "custom"}
+                    onChange={event => {
+                      const value = event.target.value;
+                      if (value === "custom") return;
+                      setCategoryDraft(value);
+                    }}
+                    className="w-full px-3 py-2 bg-dark-300 text-white border border-dark-400 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  >
+                    {CATEGORY_OPTIONS.map(option => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                    <option value="custom">Custom...</option>
+                  </select>
+                  <input
+                    type="text"
+                    value={categoryDraft}
+                    onChange={event => setCategoryDraft(event.target.value)}
+                    placeholder="Enter a category"
+                    className="w-full px-3 py-2 bg-dark-300 text-white border border-dark-400 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  />
+                  <div className="flex flex-col sm:flex-row sm:items-center gap-3 pt-1">
+                    <button
+                      type="button"
+                      onClick={handleSaveCategory}
+                      disabled={categorySaving}
+                      className="px-4 py-2 bg-primary-500 hover:bg-primary-600 text-white rounded-lg flex items-center gap-2 disabled:opacity-70"
+                    >
+                      {categorySaving && <Loader2 className="h-4 w-4 animate-spin" />}Save Category
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleAskAIAboutTransaction}
+                      className="px-4 py-2 bg-purple-500/20 hover:bg-purple-500/30 text-purple-200 rounded-lg"
+                    >
+                      Ask AI About This
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { me, seed } from "@/api/auth";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/context/Auth";
+import toast from "react-hot-toast";
 
 export default function Onboarding() {
   const [busy, setBusy] = useState(false);
@@ -23,8 +24,9 @@ export default function Onboarding() {
       const updatedUser = await me();
       setUser(updatedUser);
       nav("/dashboard");
-    } catch (error) {
-      console.error("Setup failed:", error);
+      toast.success("Demo account created successfully");
+    } catch (error: any) {
+      toast.error(error?.response?.data?.error || "Setup failed. Please try again.");
     } finally {
       setBusy(false);
     }


### PR DESCRIPTION
## Summary
- expand the Nessie user routes to surface AP2 mandate stats, persist transaction categories, and expose user-facing deposit/purchase/categorize endpoints
- wire the frontend client and chat page into the new capabilities while prefilling AI prompts from transaction context
- overhaul the dashboard with animated balances, actionable quick-action modals, richer insights, and interactive transaction categorization tied to the backend

## Testing
- pytest test_portal.py test_phases_integration.py
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccd8a0ab94832698ef7d972777b8fa