### PR TITLE
Add manual banking ledger endpoints and dark theme polish

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -30,9 +30,16 @@ service cloud.firestore {
       allow read, write: if isOwner(resource.data.user_id) || (request.resource != null && isOwner(request.resource.data.user_id));
     }
 
+    // Users can only access their own manual banking transactions
+    match /bank_transactions/{transactionId} {
+      allow read, update, delete: if isOwner(resource.data.user_id);
+      allow create: if isSignedIn() && request.resource.data.user_id == request.auth.uid;
+    }
+
     // Health checks can be read by anyone for system monitoring
     match /health_checks/{document} {
-      allow read, write: if true;
+      allow read: if true;
+      allow write: if false;
     }
   }
 }

--- a/routes/transactions.py
+++ b/routes/transactions.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+from typing import Any, Dict, List
+
 from flask import Blueprint, jsonify, request, g
 
 from routes.auth import require_auth
 from utils.firestore_db import (
+    create_manual_transaction,
     get_category_overrides,
     get_user,
+    list_manual_transactions,
     save_inflation_snapshot,
     save_plaid_cursor,
     set_category_override,
@@ -18,6 +23,55 @@ from utils.plaid_client import get_account_balances, sync_transactions
 bp = Blueprint("transactions", __name__)
 
 
+def _coerce_amount(value: Any) -> float:
+    try:
+        amount = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return round(amount, 2)
+
+
+def _coerce_date(value: Any) -> str:
+    if not value:
+        return datetime.utcnow().date().isoformat()
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    try:
+        return datetime.fromisoformat(str(value)).date().isoformat()
+    except Exception:
+        return datetime.utcnow().date().isoformat()
+
+
+def _format_manual_transaction(raw: Dict[str, Any]) -> Dict[str, Any]:
+    transaction_type = (raw.get("transaction_type") or "purchase").lower()
+    occurred_at = raw.get("occurred_at")
+    if hasattr(occurred_at, "isoformat"):
+        occurred_at = occurred_at.isoformat()
+    elif not occurred_at:
+        occurred_at = datetime.utcnow().date().isoformat()
+
+    name = raw.get("name") or raw.get("merchant_name") or raw.get("description")
+    if not name:
+        name = "Manual deposit" if transaction_type == "deposit" else "Manual purchase"
+
+    category = raw.get("category")
+    if not category:
+        category = "Income" if transaction_type == "deposit" else "Other"
+
+    transaction: Dict[str, Any] = {
+        "transaction_id": raw.get("id") or raw.get("transaction_id") or name,
+        "name": name,
+        "merchant_name": raw.get("merchant_name"),
+        "amount": _coerce_amount(raw.get("amount")),
+        "date": occurred_at,
+        "transaction_type": transaction_type,
+        "category": category,
+    }
+    if raw.get("notes"):
+        transaction["notes"] = raw["notes"]
+    return transaction
+
+
 @bp.get("/transactions")
 @require_auth
 def get_transactions():
@@ -25,25 +79,76 @@ def get_transactions():
     if not user:
         return jsonify({"error": "User not found"}), 404
 
+    manual_docs, _ = list_manual_transactions(g.uid)
+    manual_transactions = [_format_manual_transaction(doc) for doc in manual_docs]
+
     access_token = user.get("plaid_access_token")
-    if not access_token:
-        return jsonify({"error": "Plaid account not linked"}), 400
+    transactions: List[Dict[str, Any]] = []
+    next_cursor = None
+    balances: Dict[str, Any] | None = None
 
-    cursor = user.get("plaid_cursor")
-    sync = sync_transactions(access_token, cursor)
-    next_cursor = sync.get("next_cursor")
-    if next_cursor and next_cursor != cursor:
-        save_plaid_cursor(g.uid, next_cursor)
+    if access_token:
+        cursor = user.get("plaid_cursor")
+        sync = sync_transactions(access_token, cursor)
+        next_cursor = sync.get("next_cursor")
+        if next_cursor and next_cursor != cursor:
+            save_plaid_cursor(g.uid, next_cursor)
 
-    transactions = (sync.get("added") or []) + (sync.get("modified") or [])
+        transactions = (sync.get("added") or []) + (sync.get("modified") or [])
+        transactions.extend(manual_transactions)
+        balances, _ = get_account_balances(access_token)
+    else:
+        transactions = list(manual_transactions)
+
+    manual_balance = 0.0
+    for ledger_tx in manual_transactions:
+        if ledger_tx.get("transaction_type") == "deposit":
+            manual_balance += ledger_tx.get("amount", 0)
+        else:
+            manual_balance -= ledger_tx.get("amount", 0)
+    manual_balance = round(manual_balance, 2)
+
+    manual_account = {
+        "name": "Manual Spending Ledger",
+        "type": "mock",
+        "subtype": "wallet",
+        "balances": {"available": manual_balance, "current": manual_balance},
+    }
+
+    if balances and isinstance(balances, dict):
+        balances.setdefault("accounts", [])
+        balances["accounts"].append(manual_account)
+    else:
+        balances = {"accounts": [manual_account]}
+
     overrides = get_category_overrides(g.uid)
     summary = calculate_personal_inflation(transactions, overrides)
     save_inflation_snapshot(g.uid, summary)
 
-    balances, _ = get_account_balances(access_token)
+    manual_lookup = {tx["transaction_id"]: tx for tx in manual_transactions}
+    combined: List[Dict[str, Any]] = []
+    seen_ids = set()
+    for tx in summary.get("transactions", []):
+        record = dict(tx)
+        ledger_meta = manual_lookup.get(record.get("transaction_id"))
+        if ledger_meta:
+            record["transaction_type"] = ledger_meta.get("transaction_type", record.get("transaction_type", "purchase"))
+            if ledger_meta.get("notes"):
+                record["notes"] = ledger_meta["notes"]
+        else:
+            record.setdefault("transaction_type", "purchase")
+        combined.append(record)
+        seen_ids.add(record.get("transaction_id"))
+
+    for ledger_tx in manual_transactions:
+        if ledger_tx.get("transaction_id") not in seen_ids:
+            combined.append(ledger_tx)
+            seen_ids.add(ledger_tx.get("transaction_id"))
+
+    combined.sort(key=lambda item: item.get("date", ""), reverse=True)
 
     return jsonify({
-        "transactions": summary.get("transactions", []),
+        "transactions": combined,
         "category_totals": summary.get("category_totals", {}),
         "personal_inflation": {
             "personal_rate": summary.get("personal_rate"),
@@ -74,3 +179,67 @@ def override_category():
         return jsonify({"error": message}), 500
 
     return jsonify({"ok": True, "transaction_id": transaction_id, "category": category})
+
+
+@bp.post("/transactions/manual/deposit")
+@require_auth
+def create_deposit():
+    data = request.get_json() or {}
+    amount = _coerce_amount(data.get("amount"))
+    source = (data.get("source") or data.get("name") or "").strip()
+    notes = (data.get("notes") or "").strip()
+    occurred_at = _coerce_date(data.get("date") or data.get("occurred_at"))
+
+    if amount <= 0:
+        return jsonify({"error": "amount must be greater than zero"}), 400
+
+    payload = {
+        "transaction_type": "deposit",
+        "amount": amount,
+        "name": source or "Manual deposit",
+        "category": "Income",
+        "occurred_at": occurred_at,
+    }
+    if notes:
+        payload["notes"] = notes
+
+    success, result = create_manual_transaction(g.uid, payload)
+    if not success:
+        status = 503 if "not available" in result.lower() else 500
+        return jsonify({"error": result}), status
+
+    transaction = _format_manual_transaction({**payload, "id": result})
+    return jsonify({"ok": True, "transaction": transaction}), 201
+
+
+@bp.post("/transactions/manual/purchase")
+@require_auth
+def create_purchase():
+    data = request.get_json() or {}
+    amount = _coerce_amount(data.get("amount"))
+    merchant = (data.get("merchant") or data.get("name") or "").strip()
+    category = (data.get("category") or "Other").strip() or "Other"
+    notes = (data.get("notes") or "").strip()
+    occurred_at = _coerce_date(data.get("date") or data.get("occurred_at"))
+
+    if amount <= 0:
+        return jsonify({"error": "amount must be greater than zero"}), 400
+
+    payload = {
+        "transaction_type": "purchase",
+        "amount": amount,
+        "name": merchant or "Manual purchase",
+        "merchant_name": merchant or None,
+        "category": category,
+        "occurred_at": occurred_at,
+    }
+    if notes:
+        payload["notes"] = notes
+
+    success, result = create_manual_transaction(g.uid, payload)
+    if not success:
+        status = 503 if "not available" in result.lower() else 500
+        return jsonify({"error": result}), status
+
+    transaction = _format_manual_transaction({**payload, "id": result})
+    return jsonify({"ok": True, "transaction": transaction}), 201

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -31,6 +31,8 @@ export type TransactionRecord = {
   amount: number;
   date: string;
   category: string;
+  transaction_type?: string;
+  notes?: string;
 };
 
 export type TransactionsResponse = {
@@ -58,6 +60,27 @@ export const overrideTransactionCategory = async (transactionId: string, categor
     category,
   });
   return data as { ok: boolean; transaction_id: string; category: string };
+};
+
+export const createManualDeposit = async (payload: {
+  amount: number;
+  source?: string;
+  date?: string;
+  notes?: string;
+}) => {
+  const { data } = await api.post("/transactions/manual/deposit", payload);
+  return data as { ok: boolean; transaction: TransactionRecord };
+};
+
+export const createManualPurchase = async (payload: {
+  amount: number;
+  merchant?: string;
+  category: string;
+  date?: string;
+  notes?: string;
+}) => {
+  const { data } = await api.post("/transactions/manual/purchase", payload);
+  return data as { ok: boolean; transaction: TransactionRecord };
 };
 
 export const getPlaidStatus = async () => {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -29,15 +29,15 @@ export default function Navbar() {
             </div>
             <div>
               <h1 className="text-xl font-bold text-white">Inflate-Wise</h1>
-              <p className="text-xs text-dark-900">AI Personal Inflation Co-Pilot</p>
+              <p className="text-xs text-dark-300">AI Personal Inflation Co-Pilot</p>
             </div>
           </Link>
 
-          <div className="flex items-center space-x-6 text-sm text-dark-900">
+          <div className="flex items-center space-x-6 text-sm text-dark-200">
             <NavLink
               to="/chat"
               className={({ isActive }) =>
-                `transition-colors ${isActive ? "text-primary-500 font-medium" : "text-dark-900 hover:text-primary-500"}`
+                `transition-colors ${isActive ? "text-primary-400 font-medium" : "text-dark-200 hover:text-primary-400"}`
               }
             >
               Chat
@@ -45,7 +45,7 @@ export default function Navbar() {
             <NavLink
               to="/learn"
               className={({ isActive }) =>
-                `transition-colors ${isActive ? "text-primary-500 font-medium" : "text-dark-900 hover:text-primary-500"}`
+                `transition-colors ${isActive ? "text-primary-400 font-medium" : "text-dark-200 hover:text-primary-400"}`
               }
             >
               Learn
@@ -55,7 +55,7 @@ export default function Navbar() {
                 <NavLink
                   to="/dashboard"
                   className={({ isActive }) =>
-                    `transition-colors ${isActive ? "text-primary-500 font-medium" : "text-dark-900 hover:text-primary-500"}`
+                    `transition-colors ${isActive ? "text-primary-400 font-medium" : "text-dark-200 hover:text-primary-400"}`
                   }
                 >
                   Dashboard
@@ -63,7 +63,7 @@ export default function Navbar() {
                 <NavLink
                   to="/trustagent"
                   className={({ isActive }) =>
-                    `transition-colors ${isActive ? "text-primary-500 font-medium" : "text-dark-900 hover:text-primary-500"}`
+                    `transition-colors ${isActive ? "text-primary-400 font-medium" : "text-dark-200 hover:text-primary-400"}`
                   }
                 >
                   Lab
@@ -74,14 +74,14 @@ export default function Navbar() {
               <NavLink
                 to="/admin"
                 className={({ isActive }) =>
-                  `transition-colors ${isActive ? "text-primary-500 font-medium" : "text-dark-900 hover:text-primary-500"}`
+                  `transition-colors ${isActive ? "text-primary-400 font-medium" : "text-dark-200 hover:text-primary-400"}`
                 }
               >
                 Admin
               </NavLink>
             )}
 
-            <div className="hidden md:flex items-center space-x-2 text-sm text-dark-900">
+            <div className="hidden md:flex items-center space-x-2 text-sm text-dark-300">
               <TrendingUp className="w-4 h-4" />
               <span>Personal CPI in minutes</span>
             </div>
@@ -95,7 +95,7 @@ export default function Navbar() {
                     </span>
                     <button
                       onClick={handleLogout}
-                      className="flex items-center gap-1 text-dark-900 hover:text-primary-500 transition-colors"
+                      className="flex items-center gap-1 text-dark-200 hover:text-primary-400 transition-colors"
                     >
                       <LogOut className="h-4 w-4" />
                       <span>Sign Out</span>
@@ -105,7 +105,7 @@ export default function Navbar() {
                   <>
                     <Link
                       to="/login"
-                      className="text-dark-900 hover:text-primary-500 transition-colors"
+                      className="text-dark-200 hover:text-primary-400 transition-colors"
                     >
                       Sign In
                     </Link>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -9,6 +9,9 @@ import {
   Percent,
   RefreshCw,
   Sparkles,
+  PlusCircle,
+  ShoppingBag,
+  X,
 } from "lucide-react";
 import toast from "react-hot-toast";
 
@@ -17,6 +20,8 @@ import {
   overrideTransactionCategory,
   fetchPersonalInflation,
   submitReceipt,
+  createManualDeposit,
+  createManualPurchase,
   type PersonalInflationSnapshot,
   type TransactionRecord,
 } from "@/api/client";
@@ -46,6 +51,19 @@ export default function Dashboard() {
   const [receiptSummary, setReceiptSummary] = useState<string | null>(null);
   const [receiptItems, setReceiptItems] = useState<string>("");
   const [receiptTotal, setReceiptTotal] = useState<string>("");
+  const [showDepositModal, setShowDepositModal] = useState(false);
+  const [showPurchaseModal, setShowPurchaseModal] = useState(false);
+  const [depositSource, setDepositSource] = useState("");
+  const [depositAmount, setDepositAmount] = useState("");
+  const [depositDate, setDepositDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [depositNotes, setDepositNotes] = useState("");
+  const [depositSubmitting, setDepositSubmitting] = useState(false);
+  const [purchaseMerchant, setPurchaseMerchant] = useState("");
+  const [purchaseAmount, setPurchaseAmount] = useState("");
+  const [purchaseCategory, setPurchaseCategory] = useState(CATEGORY_OPTIONS[0]);
+  const [purchaseDate, setPurchaseDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [purchaseNotes, setPurchaseNotes] = useState("");
+  const [purchaseSubmitting, setPurchaseSubmitting] = useState(false);
   const { user } = useAuth();
   const navigate = useNavigate();
 
@@ -130,6 +148,86 @@ export default function Dashboard() {
     );
   };
 
+  const resetDepositForm = () => {
+    setDepositSource("");
+    setDepositAmount("");
+    setDepositNotes("");
+    setDepositDate(new Date().toISOString().slice(0, 10));
+  };
+
+  const resetPurchaseForm = () => {
+    setPurchaseMerchant("");
+    setPurchaseAmount("");
+    setPurchaseCategory(CATEGORY_OPTIONS[0]);
+    setPurchaseNotes("");
+    setPurchaseDate(new Date().toISOString().slice(0, 10));
+  };
+
+  const closeDepositModal = (force = false) => {
+    if (depositSubmitting && !force) return;
+    setShowDepositModal(false);
+    resetDepositForm();
+  };
+
+  const closePurchaseModal = (force = false) => {
+    if (purchaseSubmitting && !force) return;
+    setShowPurchaseModal(false);
+    resetPurchaseForm();
+  };
+
+  const handleCreateDeposit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const amountValue = parseFloat(depositAmount);
+    if (Number.isNaN(amountValue) || amountValue <= 0) {
+      toast.error("Enter a positive deposit amount");
+      return;
+    }
+
+    setDepositSubmitting(true);
+    try {
+      await createManualDeposit({
+        amount: amountValue,
+        source: depositSource || undefined,
+        date: depositDate || undefined,
+        notes: depositNotes || undefined,
+      });
+      toast.success("Deposit recorded");
+      closeDepositModal(true);
+      await loadDashboard(true);
+    } catch (error) {
+      toast.error("Could not record deposit");
+    } finally {
+      setDepositSubmitting(false);
+    }
+  };
+
+  const handleCreatePurchase = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const amountValue = parseFloat(purchaseAmount);
+    if (Number.isNaN(amountValue) || amountValue <= 0) {
+      toast.error("Enter a positive purchase amount");
+      return;
+    }
+
+    setPurchaseSubmitting(true);
+    try {
+      await createManualPurchase({
+        amount: amountValue,
+        merchant: purchaseMerchant || undefined,
+        category: purchaseCategory,
+        date: purchaseDate || undefined,
+        notes: purchaseNotes || undefined,
+      });
+      toast.success("Purchase logged");
+      closePurchaseModal(true);
+      await loadDashboard(true);
+    } catch (error) {
+      toast.error("Could not record purchase");
+    } finally {
+      setPurchaseSubmitting(false);
+    }
+  };
+
   return (
     <div className="space-y-8">
       <div className="flex flex-wrap items-center justify-between gap-4">
@@ -137,14 +235,30 @@ export default function Dashboard() {
           <h1 className="text-3xl font-semibold text-white">Welcome back{user?.first_name ? `, ${user.first_name}` : ""}</h1>
           <p className="text-dark-900">Here is the latest snapshot of your personal inflation.</p>
         </div>
-        <button
-          onClick={() => loadDashboard(true)}
-          disabled={updating}
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-dark-400 text-white hover:border-primary-500 hover:text-primary-200 transition disabled:opacity-60"
-        >
-          {updating ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
-          Refresh data
-        </button>
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            onClick={() => setShowDepositModal(true)}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-emerald-500/40 bg-emerald-500/20 text-emerald-200 hover:bg-emerald-500/30 transition"
+          >
+            <PlusCircle className="w-4 h-4" />
+            Add deposit
+          </button>
+          <button
+            onClick={() => setShowPurchaseModal(true)}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-primary-500 hover:bg-primary-600 text-white transition"
+          >
+            <ShoppingBag className="w-4 h-4" />
+            Make purchase
+          </button>
+          <button
+            onClick={() => loadDashboard(true)}
+            disabled={updating}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-dark-400 text-white hover:border-primary-500 hover:text-primary-200 transition disabled:opacity-60"
+          >
+            {updating ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
+            Refresh data
+          </button>
+        </div>
       </div>
 
       <div className="grid md:grid-cols-3 gap-6">
@@ -247,26 +361,31 @@ export default function Dashboard() {
                   </td>
                 </tr>
               ) : transactions.length ? (
-                transactions.map(tx => (
-                  <tr key={tx.transaction_id} className="border-b border-dark-400/30 last:border-0">
-                    <td className="py-3 pr-4 text-white">{tx.merchant_name || tx.name}</td>
-                    <td className="py-3 pr-4 text-dark-900">{new Date(tx.date).toLocaleDateString()}</td>
-                    <td className="py-3 pr-4 text-white">${tx.amount.toFixed(2)}</td>
-                    <td className="py-3 pr-4">
-                      <select
-                        value={overrides[tx.transaction_id] || tx.category}
-                        onChange={event => handleOverride(tx.transaction_id, event.target.value)}
-                        className="bg-dark-300/60 border border-dark-400 rounded-lg px-3 py-2 text-sm text-white"
-                      >
-                        {CATEGORY_OPTIONS.map(option => (
-                          <option key={option} value={option}>
-                            {option}
-                          </option>
-                        ))}
-                      </select>
-                    </td>
-                  </tr>
-                ))
+                transactions.map(tx => {
+                  const isDeposit = (tx.transaction_type || "").toLowerCase() === "deposit";
+                  return (
+                    <tr key={tx.transaction_id} className="border-b border-dark-400/30 last:border-0">
+                      <td className="py-3 pr-4 text-white">{tx.merchant_name || tx.name}</td>
+                      <td className="py-3 pr-4 text-dark-900">{new Date(tx.date).toLocaleDateString()}</td>
+                      <td className={`py-3 pr-4 ${isDeposit ? "text-emerald-300" : "text-white"}`}>
+                        {isDeposit ? "+" : "-"}${tx.amount.toFixed(2)}
+                      </td>
+                      <td className="py-3 pr-4">
+                        <select
+                          value={overrides[tx.transaction_id] || tx.category}
+                          onChange={event => handleOverride(tx.transaction_id, event.target.value)}
+                          className="bg-dark-300/60 border border-dark-400 rounded-lg px-3 py-2 text-sm text-white"
+                        >
+                          {CATEGORY_OPTIONS.map(option => (
+                            <option key={option} value={option}>
+                              {option}
+                            </option>
+                          ))}
+                        </select>
+                      </td>
+                    </tr>
+                  );
+                })
               ) : (
                 <tr>
                   <td colSpan={4} className="py-6 text-center text-dark-800">
@@ -323,6 +442,190 @@ export default function Dashboard() {
           </form>
         </CardContent>
       </Card>
+      {showDepositModal && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm px-4"
+          onClick={() => closeDepositModal()}
+        >
+          <div
+            className="w-full max-w-md rounded-2xl border border-dark-400 bg-dark-200 p-6 shadow-2xl"
+            onClick={event => event.stopPropagation()}
+          >
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-white">Record a deposit</h2>
+              <button
+                type="button"
+                onClick={() => closeDepositModal()}
+                className="text-dark-900 hover:text-white transition"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <form onSubmit={handleCreateDeposit} className="space-y-4 text-sm text-white">
+              <div>
+                <label className="block text-dark-900 mb-1 font-medium">Source</label>
+                <input
+                  value={depositSource}
+                  onChange={event => setDepositSource(event.target.value)}
+                  placeholder="Employer payroll"
+                  className="w-full rounded-lg border border-dark-400 bg-dark-300 px-4 py-3 text-white placeholder-dark-700 focus:border-primary-500 focus:outline-none"
+                />
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-dark-900 mb-1 font-medium">Amount</label>
+                  <input
+                    value={depositAmount}
+                    onChange={event => setDepositAmount(event.target.value)}
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    required
+                    className="w-full rounded-lg border border-dark-400 bg-dark-300 px-4 py-3 text-white placeholder-dark-700 focus:border-primary-500 focus:outline-none"
+                    placeholder="1500"
+                  />
+                </div>
+                <div>
+                  <label className="block text-dark-900 mb-1 font-medium">Date</label>
+                  <input
+                    value={depositDate}
+                    onChange={event => setDepositDate(event.target.value)}
+                    type="date"
+                    className="w-full rounded-lg border border-dark-400 bg-dark-300 px-4 py-3 text-white focus:border-primary-500 focus:outline-none"
+                  />
+                </div>
+              </div>
+              <div>
+                <label className="block text-dark-900 mb-1 font-medium">Notes (optional)</label>
+                <textarea
+                  value={depositNotes}
+                  onChange={event => setDepositNotes(event.target.value)}
+                  className="w-full rounded-lg border border-dark-400 bg-dark-300 px-4 py-3 text-white placeholder-dark-700 focus:border-primary-500 focus:outline-none"
+                  rows={3}
+                  placeholder="April salary"
+                />
+              </div>
+              <div className="flex justify-end gap-3">
+                <button
+                  type="button"
+                  onClick={() => closeDepositModal()}
+                  className="inline-flex items-center gap-2 rounded-lg border border-dark-400 px-4 py-2 text-dark-900 hover:text-white transition"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={depositSubmitting}
+                  className="inline-flex items-center gap-2 rounded-lg bg-emerald-500 hover:bg-emerald-600 px-4 py-2 text-white transition disabled:opacity-60"
+                >
+                  {depositSubmitting ? <Loader2 className="w-4 h-4 animate-spin" /> : <PlusCircle className="w-4 h-4" />}
+                  Save deposit
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+      {showPurchaseModal && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm px-4"
+          onClick={() => closePurchaseModal()}
+        >
+          <div
+            className="w-full max-w-lg rounded-2xl border border-dark-400 bg-dark-200 p-6 shadow-2xl"
+            onClick={event => event.stopPropagation()}
+          >
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-white">Log a purchase</h2>
+              <button
+                type="button"
+                onClick={() => closePurchaseModal()}
+                className="text-dark-900 hover:text-white transition"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <form onSubmit={handleCreatePurchase} className="space-y-4 text-sm text-white">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-dark-900 mb-1 font-medium">Merchant</label>
+                  <input
+                    value={purchaseMerchant}
+                    onChange={event => setPurchaseMerchant(event.target.value)}
+                    placeholder="Local grocer"
+                    className="w-full rounded-lg border border-dark-400 bg-dark-300 px-4 py-3 text-white placeholder-dark-700 focus:border-primary-500 focus:outline-none"
+                  />
+                </div>
+                <div>
+                  <label className="block text-dark-900 mb-1 font-medium">Date</label>
+                  <input
+                    value={purchaseDate}
+                    onChange={event => setPurchaseDate(event.target.value)}
+                    type="date"
+                    className="w-full rounded-lg border border-dark-400 bg-dark-300 px-4 py-3 text-white focus:border-primary-500 focus:outline-none"
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-dark-900 mb-1 font-medium">Amount</label>
+                  <input
+                    value={purchaseAmount}
+                    onChange={event => setPurchaseAmount(event.target.value)}
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    required
+                    className="w-full rounded-lg border border-dark-400 bg-dark-300 px-4 py-3 text-white placeholder-dark-700 focus:border-primary-500 focus:outline-none"
+                    placeholder="82.45"
+                  />
+                </div>
+                <div>
+                  <label className="block text-dark-900 mb-1 font-medium">Category</label>
+                  <select
+                    value={purchaseCategory}
+                    onChange={event => setPurchaseCategory(event.target.value)}
+                    className="w-full rounded-lg border border-dark-400 bg-dark-300 px-4 py-3 text-white focus:border-primary-500 focus:outline-none"
+                  >
+                    {CATEGORY_OPTIONS.map(option => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div>
+                <label className="block text-dark-900 mb-1 font-medium">Notes (optional)</label>
+                <textarea
+                  value={purchaseNotes}
+                  onChange={event => setPurchaseNotes(event.target.value)}
+                  className="w-full rounded-lg border border-dark-400 bg-dark-300 px-4 py-3 text-white placeholder-dark-700 focus:border-primary-500 focus:outline-none"
+                  rows={3}
+                  placeholder="Weekly groceries and household staples"
+                />
+              </div>
+              <div className="flex justify-end gap-3">
+                <button
+                  type="button"
+                  onClick={() => closePurchaseModal()}
+                  className="inline-flex items-center gap-2 rounded-lg border border-dark-400 px-4 py-2 text-dark-900 hover:text-white transition"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={purchaseSubmitting}
+                  className="inline-flex items-center gap-2 rounded-lg bg-primary-500 hover:bg-primary-600 px-4 py-2 text-white transition disabled:opacity-60"
+                >
+                  {purchaseSubmitting ? <Loader2 className="w-4 h-4 animate-spin" /> : <ShoppingBag className="w-4 h-4" />}
+                  Save purchase
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -44,12 +44,12 @@ export default function LoginPage() {
       <div className="max-w-2xl w-full bg-dark-200 border border-dark-400 rounded-2xl shadow-xl p-8">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-white mb-2">Welcome Back</h1>
-          <p className="text-dark-900">Sign in to your Houston Financial Navigator account</p>
+          <p className="text-dark-300">Sign in to your Houston Financial Navigator account</p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4 text-white">
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-dark-900 mb-1">
+            <label htmlFor="email" className="block text-sm font-medium text-dark-200 mb-1">
               Email
             </label>
             <input
@@ -64,7 +64,7 @@ export default function LoginPage() {
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-dark-900 mb-1">
+            <label htmlFor="password" className="block text-sm font-medium text-dark-200 mb-1">
               Password
             </label>
             <input
@@ -95,7 +95,7 @@ export default function LoginPage() {
         </form>
 
         <div className="mt-6 text-center">
-          <p className="text-dark-900">
+          <p className="text-dark-300">
             Don't have an account?{" "}
             <Link to="/register" className="text-primary-500 hover:text-primary-400 font-medium">
               Sign up

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -75,14 +75,14 @@ export default function Onboarding() {
         <Card className="bg-dark-200/60 border border-dark-400/60">
           <CardHeader>
             <CardTitle className="text-white text-2xl">Connect your accounts</CardTitle>
-            <p className="text-dark-900 text-sm">
+            <p className="text-dark-300 text-sm">
               Inflate-Wise uses Plaid to securely pull transactions so Gemini can personalise your inflation model.
             </p>
           </CardHeader>
           <CardContent className="space-y-6">
             <div className="bg-dark-300/50 border border-dark-400/60 rounded-xl p-6 space-y-4">
               <h3 className="text-lg font-semibold text-white">Step 1 · Generate a Plaid Link token</h3>
-              <p className="text-dark-900 text-sm">
+              <p className="text-dark-300 text-sm">
                 In production this token is passed into Plaid Link on the client. For the hackathon sandbox, click the button to create a token and preview the payload.
               </p>
               <button
@@ -101,7 +101,7 @@ export default function Onboarding() {
 
             <div className="bg-dark-300/50 border border-dark-400/60 rounded-xl p-6 space-y-4">
               <h3 className="text-lg font-semibold text-white">Step 2 · Complete sandbox linking</h3>
-              <p className="text-dark-900 text-sm">
+              <p className="text-dark-300 text-sm">
                 Normally Plaid Link returns a public token. We simulate that handshake here so you can move straight to the dashboard.
               </p>
               <button
@@ -111,7 +111,7 @@ export default function Onboarding() {
               >
                 {loading ? "Linking..." : "Exchange sandbox token"}
               </button>
-              <p className="text-dark-800 text-xs">
+              <p className="text-dark-400 text-xs">
                 Tip: in production you would launch Plaid Link and call this endpoint inside the onSuccess callback.
               </p>
             </div>
@@ -126,7 +126,7 @@ export default function Onboarding() {
                   </div>
                 </>
               ) : (
-                <p className="text-dark-900 text-sm">No financial institutions linked yet.</p>
+                <p className="text-dark-300 text-sm">No financial institutions linked yet.</p>
               )}
             </div>
           </CardContent>

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -43,13 +43,13 @@ export default function RegisterPage() {
       <div className="max-w-2xl w-full bg-dark-200 border border-dark-400 rounded-2xl shadow-xl p-8">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-white mb-2">Join Houston Financial Navigator</h1>
-          <p className="text-dark-900">Create your account to start your financial journey</p>
+          <p className="text-dark-300">Create your account to start your financial journey</p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4 text-white">
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label htmlFor="first_name" className="block text-sm font-medium text-dark-900 mb-1">
+              <label htmlFor="first_name" className="block text-sm font-medium text-dark-200 mb-1">
                 First Name
               </label>
               <input
@@ -63,7 +63,7 @@ export default function RegisterPage() {
               />
             </div>
             <div>
-              <label htmlFor="last_name" className="block text-sm font-medium text-dark-900 mb-1">
+              <label htmlFor="last_name" className="block text-sm font-medium text-dark-200 mb-1">
                 Last Name
               </label>
               <input
@@ -79,7 +79,7 @@ export default function RegisterPage() {
           </div>
 
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-dark-900 mb-1">
+            <label htmlFor="email" className="block text-sm font-medium text-dark-200 mb-1">
               Email
             </label>
             <input
@@ -95,7 +95,7 @@ export default function RegisterPage() {
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-dark-900 mb-1">
+            <label htmlFor="password" className="block text-sm font-medium text-dark-200 mb-1">
               Password
             </label>
             <input
@@ -127,7 +127,7 @@ export default function RegisterPage() {
         </form>
 
         <div className="mt-6 text-center">
-          <p className="text-dark-900">
+          <p className="text-dark-300">
             Already have an account?{" "}
             <Link to="/login" className="text-primary-500 hover:text-primary-400 font-medium">
               Sign in

--- a/utils/inflation.py
+++ b/utils/inflation.py
@@ -74,6 +74,8 @@ def normalise_transactions(transactions: Iterable[Dict[str, Any]], *, months: in
     cutoff = datetime.utcnow().date() - timedelta(days=30 * max(months, 1))
     clean: List[Dict[str, Any]] = []
     for tx in transactions:
+        if (tx.get("transaction_type") or "").lower() == "deposit":
+            continue
         amount = float(tx.get("amount") or 0)
         if amount <= 0:
             continue


### PR DESCRIPTION
## Summary
- add secure Firestore rules and helpers for storing per-user manual banking transactions
- expose authenticated API routes and dashboard workflows for recording deposits and purchases without Plaid
- align login, onboarding and navigation styles with the dark theme for a cohesive experience

## Testing
- npm run build
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd0faf34dc8326ba5429a49d2fcdb7